### PR TITLE
Installation fixes (some may be Windows-specific, some not)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,12 +26,12 @@ fixup_locale:
 snag_docs: Documentation/man1/git-filter-repo.1 Documentation/html/git-filter-repo.html
 
 Documentation/man1/git-filter-repo.1:
-	mkdir -p man1
-	git show docs:man1/git-filter-repo.1 >Documentation/man1/git-filter-repo.1
+	mkdir -p Documentation/man1
+	git show origin/docs:man1/git-filter-repo.1 >Documentation/man1/git-filter-repo.1
 
 Documentation/html/git-filter-repo.html:
-	mkdir -p html
-	git show docs:html/git-filter-repo.html >Documentation/html/git-filter-repo.html
+	mkdir -p Documentation/html
+	git show origin/docs:html/git-filter-repo.html >Documentation/html/git-filter-repo.html
 
 install: snag_docs #fixup_locale
 	cp -a git-filter-repo $(bindir)/

--- a/Makefile
+++ b/Makefile
@@ -34,10 +34,10 @@ Documentation/html/git-filter-repo.html:
 	git show origin/docs:html/git-filter-repo.html >Documentation/html/git-filter-repo.html
 
 install: snag_docs #fixup_locale
-	cp -a git-filter-repo $(bindir)/
-	ln -s $(bindir)/git-filter-repo $(pythondir)/git_filter_repo.py
-	cp -a Documentation/man1/git-filter-repo.1 $(mandir)/man1/git-filter-repo.1
-	cp -a Documentation/html/git-filter-repo.html $(htmldir)/git-filter-repo.html
+	cp -a git-filter-repo "$(bindir)/"
+	ln -sf "$(bindir)/git-filter-repo" "$(pythondir)/git_filter_repo.py"
+	cp -a Documentation/man1/git-filter-repo.1 "$(mandir)/man1/git-filter-repo.1"
+	cp -a Documentation/html/git-filter-repo.html "$(htmldir)/git-filter-repo.html"
 
 
 #


### PR DESCRIPTION
- documentation fixes
- fix for paths with spaces
- python shebang fix, which you may not want, and might just be an issue with my own installation (I can only use "#!/usr/bin/env python", not "python3")

Side-note:
here's what ended up working for me to install on Windows:
  git clone -c core.symlinks=true https://github.com/newren/git-filter-repo.git
  make prefix="C:\Program Files\Git\mingw64" pythondir="C:\Python38\Lib\site-packages" mandir="C:\gnuwin32\share\man" install

- The git path I believe is standard for a Git for Windows install
- Python path is from a fresh chocolatey install
- gnuwin32: not sure if it was installed by Git for Windows, or by me from earlier...