### PR TITLE
Fixes for #12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,12 +26,17 @@ fixup_locale:
 snag_docs: Documentation/man1/git-filter-repo.1 Documentation/html/git-filter-repo.html
 
 Documentation/man1/git-filter-repo.1:
-	mkdir -p man1
-	git show docs:man1/git-filter-repo.1 >Documentation/man1/git-filter-repo.1
+	mkdir -p Documentation/man1
+	# Create the local `docs` tracking branch if it doesn't already exist.
+	# Fancier stream-handling could be used to ensure that errors remain on stdout.
+	git branch docs origin/docs 2>&1 | grep -v already
+	git show origin/docs:man1/git-filter-repo.1 >Documentation/man1/git-filter-repo.1
 
 Documentation/html/git-filter-repo.html:
-	mkdir -p html
-	git show docs:html/git-filter-repo.html >Documentation/html/git-filter-repo.html
+	mkdir -p Documentation/html
+	# See comment above
+	git branch docs origin/docs 2>&1 | grep -v already
+	git show origin/docs:html/git-filter-repo.html >Documentation/html/git-filter-repo.html
 
 install: snag_docs #fixup_locale
 	cp -a git-filter-repo $(bindir)/


### PR DESCRIPTION
Create 'docs' branch if necessary; create Documentation subdirs

Addresses concerns in #12 