### PR TITLE
Add packaging scripts for uploading to PyPI.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,9 @@ release: update_docs
 	cat asset_id | xargs -I ASSET_ID curl -s -H "Authorization: token $(GITHUB_COM_TOKEN)" -H "Content-Type: application/octet-stream" --data-binary @$(FILEBASE).tar.xz https://uploads.github.com/repos/newren/git-filter-repo/releases/ASSET_ID/assets?name=$(FILEBASE).tar.xz
 	# Remove temporary file(s)
 	rm asset_id
+	# Upload to PyPI, automatically picking up the new tag
+	cd release && python3 setup.py sdist bdist_wheel
+	twine upload release/dist/*
 	# Notify of completion
 	@echo
 	@echo === filter-repo $(TAGNAME) created and uploaded to GitHub ===

--- a/release/git-filter-repo
+++ b/release/git-filter-repo
@@ -1,0 +1,1 @@
+../git-filter-repo

--- a/release/git_filter_repo.py
+++ b/release/git_filter_repo.py
@@ -1,0 +1,1 @@
+../git_filter_repo.py

--- a/release/pyproject.toml
+++ b/release/pyproject.toml
@@ -1,0 +1,9 @@
+[build-system]
+requires = [
+    # The minimum setuptools version is specific to the PEP 517 backend,
+    # and may be stricter than the version required in `setup.py`
+    "setuptools>=40.6.0",
+    "setuptools_scm",
+    "wheel",
+]
+build-backend = "setuptools.build_meta"

--- a/release/setup.cfg
+++ b/release/setup.cfg
@@ -1,0 +1,29 @@
+[metadata]
+name = git-filter-repo
+url = https://github.com/newren/git-filter-repo
+project_urls =
+    Source = https://github.com/newren/git-filter-repo
+    Issues = https://github.com/newren/git-filter-repo/issues/
+description = Quickly rewrite git repository history
+long_description = file: README.md
+classifiers =
+    Development Status :: 4 - Beta
+    Operating System :: OS Independent
+    Programming Language :: Python
+    License :: OSI Approved :: MIT License
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: Implementation :: CPython
+    Programming Language :: Python :: Implementation :: PyPy
+
+[options]
+scripts = git-filter-repo
+py_modules = git_filter_repo
+python_requires = >= 3.5
+setup_requires = setuptools_scm
+
+[bdist_wheel]
+universal = 1

--- a/release/setup.py
+++ b/release/setup.py
@@ -1,0 +1,2 @@
+from setuptools import setup
+setup(use_scm_version=dict(root="..", relative_to=__file__))


### PR DESCRIPTION
Closes: #11.

After including these, you'd upload to PyPI by running e.g. `python3 setup.py sdist bdist_wheel && twine upload dist/*`.

(You'd need [twine](https://pypi.org/project/twine/) installed, so if you don't already have it, first e.g. `python3 -m venv venv && venv/bin/python -m pip install twine`)