### PR TITLE
Fix translation of mailmap entries with no email address

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/t/test-results
+/t/trash directory*

--- a/git-filter-repo
+++ b/git-filter-repo
@@ -267,7 +267,7 @@ class MailmapInfo(object):
     self._parse_file(filename)
 
   def _parse_file(self, filename):
-    name_and_email_re = re.compile(br'(.*?)\s*<([^>]+)>\s*')
+    name_and_email_re = re.compile(br'(.*?)\s*<([^>]*)>\s*')
     comment_re = re.compile(br'\s*#.*')
     if not os.access(filename, os.R_OK):
       raise SystemExit(_("Cannot read %s") % decode(filename))

--- a/git-filter-repo
+++ b/git-filter-repo
@@ -3562,7 +3562,7 @@ class RepoFilter(object):
       self._output = open(self._fe_filt, 'bw')
     else:
       self._output = self._fip.stdin
-    if self._args.debug:
+    if self._args.debug and not self._args.dry_run:
       self._output = DualFileWriter(self._fip.stdin, self._output)
       tmp = [decode(x) if isinstance(x, bytes) else x for x in fip_cmd]
       print("[DEBUG] Running: {}".format(' '.join(tmp)))

--- a/t/t9390-filter-repo.sh
+++ b/t/t9390-filter-repo.sh
@@ -48,6 +48,7 @@ filter_testcase degenerate degenerate-keepme   --path moduleA/keepme
 filter_testcase degenerate degenerate-moduleA  --path moduleA
 filter_testcase degenerate degenerate-globme   --path-glob *me
 filter_testcase unusual unusual-filtered --path ''
+filter_testcase unusual unusual-mailmap  --mailmap ../t9390/sample-mailmap
 
 test_expect_success 'setup path_rename' '
 	test_create_repo path_rename &&

--- a/t/t9390-filter-repo.sh
+++ b/t/t9390-filter-repo.sh
@@ -444,6 +444,33 @@ test_expect_success '--dry-run' '
 	)
 '
 
+test_expect_success '--dry-run --debug' '
+	(
+		git clone file://"$(pwd)"/metasyntactic dry_run_debug &&
+		cd dry_run_debug &&
+
+		git filter-repo --path words --dry-run --debug &&
+
+		git show-ref | grep master >out &&
+		test_line_count = 2 out &&
+		awk "{print \$1}" out | uniq >out2 &&
+		test_line_count = 1 out2 &&
+
+		test $(git rev-list --count HEAD) = 3 &&
+		git cat-file --batch-check --batch-all-objects >all-objs &&
+		test_line_count = 19 all-objs &&
+		git log --format=%n --name-only | sort | uniq >filenames &&
+		test_line_count = 9 filenames &&
+
+		test_path_is_file .git/filter-repo/fast-export.original &&
+		grep "^commit " .git/filter-repo/fast-export.original >out &&
+		test_line_count = 3 out &&
+		test_path_is_file .git/filter-repo/fast-export.filtered &&
+		grep "^commit " .git/filter-repo/fast-export.filtered >out &&
+		test_line_count = 2 out
+	)
+'
+
 test_expect_success '--dry-run --stdin' '
 	(
 		git clone file://"$(pwd)"/metasyntactic dry_run_stdin &&

--- a/t/t9390/sample-mailmap
+++ b/t/t9390/sample-mailmap
@@ -4,3 +4,4 @@ Little 'ol Me <me@little.net>
 Little 'ol Me <me@little.net> Little O. Me
 Little 'ol Me <me@little.net> <me@fire.com>
 Little 'ol Me <me@little.net> Little Me <me@bigcompany.com>
+Little John <second@merry.men> little.john <>

--- a/t/t9390/unusual
+++ b/t/t9390/unusual
@@ -28,7 +28,7 @@ from :2
 tag v1.0
 from :2
 original-oid 0000000000000000000000000000000000000003
-tagger Little John <second@merry.men> 1535229618 -0700
+tagger little.john <> 1535229618 -0700
 data 4
 v1.0
 

--- a/t/t9390/unusual-mailmap
+++ b/t/t9390/unusual-mailmap
@@ -17,7 +17,7 @@ from :2
 
 tag v1.0
 from :2
-tagger little.john <> 1535229618 -0700
+tagger Little John <second@merry.men> 1535229618 -0700
 data 4
 v1.0
 done


### PR DESCRIPTION
This PR adds a `.gitignore` file and fixes two bugs.

1. The mailmap format parsed by the `git shortlog` command allows for matching mailmap entries with no email address. This is admittedly an edge case, because most Git commits will have an email address associated with them as well as a name, but technically the address isn't required, and `git shortlog` accommodates that in its mailmap format. This PR teaches `git-filter-repo` to do the same thing, fixing what was arguably a bug (or at least a missing feature) in `git-filter-repo`.

2. I ran into this bug by accident while I was investigating the previous one. Prior to the changes made in this PR, `git-filter-repo` could only be used with either the `--dry-run` flag or the `--debug` flag, not both. When run in debug mode, `git-filter-repo` expected to be able to read from the output stream, which obviously isn't created when doing a dry run, so it stack traced when it tried to use the non-existent output stream. This PR fixes that bug with an equally simple sanity check for the existence of the output stream when run in debug mode.