### PR TITLE
setup.py: test for FileExistsError on symlink

### DIFF
--- a/release/setup.py
+++ b/release/setup.py
@@ -1,5 +1,8 @@
 from setuptools import setup
 import os
 for f in ['git-filter-repo', 'git_filter_repo.py', 'README.md']:
-  os.symlink("../"+f, f)
+    try:
+        os.symlink("../"+f, f)
+    except FileExistsError:
+        pass
 setup(use_scm_version=dict(root="..", relative_to=__file__))


### PR DESCRIPTION
Multiple runs of setuptools encounter a FileExistsError exception
trying to re-symlink the same files.

This exception is safe to ignore: the files were already symlinked
so the call can be considered successful.

Signed-off-by: Sirio Balmelli <sirio@b-ad.ch>