### PR TITLE
Handle encoding of unicode/unicode big endian/utf8

### DIFF
--- a/git-filter-repo
+++ b/git-filter-repo
@@ -2118,6 +2118,13 @@ EXAMPLES
       for line in f:
         line = line.rstrip(b'\r\n')
 
+        # Unicode
+        line = line.lstrip(b'\xff\xfe1\x00')
+        # Unicode big endian
+        line = line.lstrip(b'\xfe\xff\x001')
+        # utf8
+        line = line.lstrip(b'\xef\xbb\xbf1')
+
         # Skip blank lines
         if not line:
           continue


### PR DESCRIPTION
When the parameter --paths-from-file point to a non-ASCII text file, the first line start with extra bytes indicates the file's encoding. The following 3 types are handled.

```
        # Unicode
        line = line.lstrip(b'\xff\xfe1\x00')
        # Unicode big endian
        line = line.lstrip(b'\xfe\xff\x001')
        # utf8
        line = line.lstrip(b'\xef\xbb\xbf1')
```