### PR TITLE
lint-history: note that filename is absolute

### DIFF
--- a/contrib/filter-repo-demos/lint-history
+++ b/contrib/filter-repo-demos/lint-history
@@ -59,6 +59,9 @@ example_text = '''CALLBACK
         def is_relevant(filename):
             BODY
 
+    Where filename is a fully qualified file name. The file is located in a temporary directory
+    that can be specified via TMPDIR environment variable.
+
     Thus, to only run on files with a ".txt" extension you would run
         lint-history --relevant 'return filename.endswith(b".txt")' ...
 


### PR DESCRIPTION
Describe `filename` argument for `--relevant` option.