### PR TITLE
filter-repo: only set author from committer if author_email not set

### DIFF
--- a/git-filter-repo
+++ b/git-filter-repo
@@ -1189,13 +1189,14 @@ class FastExportParser(object):
       original_id = self._parse_original_id();
 
     author_name = None
+    author_email = None
     if self._currentline.startswith(b'author'):
       (author_name, author_email, author_date) = self._parse_user(b'author')
 
     (committer_name, committer_email, committer_date) = \
       self._parse_user(b'committer')
 
-    if not author_name:
+    if not author_name and not author_email:
       (author_name, author_email, author_date) = \
         (committer_name, committer_email, committer_date)
 

--- a/t/t9390/unusual
+++ b/t/t9390/unusual
@@ -32,4 +32,13 @@ tagger little.john <> 1535229618 -0700
 data 4
 v1.0
 
+commit refs/heads/other
+mark :3
+original-oid 0000000000000000000000000000000000000004
+author  <me@little.net> 1535228578 +0500
+committer Srinivasa Ramanujan <fellow@cambridge.org> 1535228580 +0500
+data 8
+Initial
+M 100644 :1 greeting
+
 done

--- a/t/t9390/unusual-filtered
+++ b/t/t9390/unusual-filtered
@@ -3,9 +3,18 @@ blob
 mark :1
 data 5
 hello
+reset refs/heads/other
+commit refs/heads/other
+mark :2
+author  <me@little.net> 1535228578 +0500
+committer Srinivasa Ramanujan <fellow@cambridge.org> 1535228580 +0500
+data 8
+Initial
+M 100644 :1 greeting
+
 reset refs/heads/develop
 commit refs/heads/develop
-mark :2
+mark :3
 author Srinivasa Ramanujan <fellow@cambridge.org> 1535228562 +051800
 committer Srinivasa Ramanujan <fellow@cambridge.org> 1535228562 +051800
 data 8
@@ -13,10 +22,10 @@ Initial
 M 100644 :1 greeting
 
 reset refs/heads/master
-from :2
+from :3
 
 tag v1.0
-from :2
+from :3
 tagger little.john <> 1535229618 -0700
 data 4
 v1.0

--- a/t/t9390/unusual-mailmap
+++ b/t/t9390/unusual-mailmap
@@ -3,9 +3,18 @@ blob
 mark :1
 data 5
 hello
+reset refs/heads/other
+commit refs/heads/other
+mark :2
+author Little 'ol Me <me@little.net> 1535228578 +0500
+committer Srinivasa Ramanujan <fellow@cambridge.org> 1535228580 +0500
+data 8
+Initial
+M 100644 :1 greeting
+
 reset refs/heads/develop
 commit refs/heads/develop
-mark :2
+mark :3
 author Srinivasa Ramanujan <fellow@cambridge.org> 1535228562 +051800
 committer Srinivasa Ramanujan <fellow@cambridge.org> 1535228562 +051800
 data 8
@@ -13,10 +22,10 @@ Initial
 M 100644 :1 greeting
 
 reset refs/heads/master
-from :2
+from :3
 
 tag v1.0
-from :2
+from :3
 tagger Little John <second@merry.men> 1535229618 -0700
 data 4
 v1.0


### PR DESCRIPTION
Some commits may have a valid author_email, but no valid author_name.
Setting the author data from the committer is wrong in this case.

Example: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=c6295cdf656de63d6d1123def71daba6cd91939c