### PR TITLE
[MailmapInfo] Ignore case for email address

### DIFF
--- a/git-filter-repo
+++ b/git-filter-repo
@@ -320,7 +320,7 @@ class MailmapInfo(object):
     for old, new in self.changes.items():
       old_name, old_email = old
       new_name, new_email = new
-      if (email == old_email or not old_email) and (
+      if (email.lower() == old_email.lower() or not old_email) and (
           name  == old_name  or not old_name):
         return (new_name or name, new_email or email)
     return (name, email)


### PR DESCRIPTION
`git shortlog` ignores the case when matching the email address. As such, `git filter-repo` should do the same.