### PR TITLE
filter-lamely: fix NameError because of forgotten fr module prefix

### DIFF
--- a/contrib/filter-repo-demos/filter-lamely
+++ b/contrib/filter-repo-demos/filter-lamely
@@ -575,7 +575,7 @@ class UserInterfaceNightmare:
       return
 
     tag.skip()
-    reset = Reset(tag.ref, tag.from_ref)
+    reset = fr.Reset(tag.ref, tag.from_ref)
     self.filter.insert(reset, direct_insertion = False)
 
   def muck_stuff_up(self):


### PR DESCRIPTION
I have succesfully used `git-filter-repo` for cleanup after migrating a lot of repos from SVN to Git and subsequent consolidation of many small repos into bigger combined repos. Thanks again for maintaining this useful tool!

I even promise I did most of that work using proper `git-filter-repo` commands! However, I recently had to reach for `filter-lamely` again for line ending conversion and noticed that it breaks when the repo has annotated tags because of a missing module prefix. This PR should fix that.