### PR TITLE
filter-repo: Support GIT_COMMIT env-var for filter callbacks

### DIFF
--- a/git-filter-repo
+++ b/git-filter-repo
@@ -3357,6 +3357,11 @@ class RepoFilter(object):
     commit.file_changes = [v for k,v in sorted(new_file_changes.items())]
 
   def _tweak_commit(self, commit, aux_info):
+    # Callbacks are provided environment variables related to commit
+    # similarly to filter-branch
+    # https://git-scm.com/docs/git-filter-branch#_filters
+    os.environ["GIT_COMMIT"] = commit.original_id.decode('utf-8')
+
     # Change the commit message according to callback
     if not self._args.preserve_commit_hashes:
       commit.message = self._hash_re.sub(self._translate_commit_hash,

--- a/t/t9392-python-callback.sh
+++ b/t/t9392-python-callback.sh
@@ -64,9 +64,9 @@ test_expect_success '--message-callback' '
 	setup message-callback &&
 	(
 		cd message-callback &&
-		git filter-repo --message-callback "return b\"TLDR: \"+message[0:5]" &&
+		git filter-repo --message-callback "return b\"TLDR: \"+message[0:5]+b\" \"+os.environ[\"GIT_COMMIT\"].encode(\"utf-8\")" &&
 		git log --format=%s >log-messages &&
-		grep TLDR:...... log-messages >modified-messages &&
+		grep "TLDR:...... .\{40\}" log-messages >modified-messages &&
 		test_line_count = 6 modified-messages
 	)
 '


### PR DESCRIPTION
GIT_COMMIT is one of a variety of environment variables supported
by git-filter-branch documented in
https://git-scm.com/docs/git-filter-branch#_filters

Filter callbacks may now access this env var

Signed-off-by: Nipunn Koorapati <nipunn@dropbox.com>