### PR TITLE
filter-repo doc: Document --name-callback as shorthand

### DIFF
--- a/Documentation/git-filter-repo.txt
+++ b/Documentation/git-filter-repo.txt
@@ -1039,6 +1039,15 @@ def name_callback(name):
   return name.replace(b"Wiliam", b"William")
 --------------------------------------------------
 
+The above `--name-callback` incanatation is shorthand for this raw `--commit-callback`
+
+--------------------------------------------------
+git-filter-repo --commit-callback '
+	commit.author_name = commit.author_name.replace(b"Wiliam", b"William")
+	commit.committer_name = commit.committer_name.replace(b"Wiliam", b"William")
+'
+--------------------------------------------------
+
 The email callback is quite similar:
 
 --------------------------------------------------


### PR DESCRIPTION
Make it easier to observe how --name-callback relates
to --commit-callback

Signed-off-by: Nipunn Koorapati <nipunn@dropbox.com>