### PR TITLE
Re-useable test-runner script

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,21 +24,11 @@ jobs:
         printf '#!/bin/sh\n\nexec python "$@"\n' >python3 &&
 
         export PATH=$PWD:$PATH &&
-        export PYTHONPATH=$PWD &&
-        export TEST_SHELL_PATH=/bin/sh &&
 
-        failed=0 &&
-        cd t &&
-        for t in t[0-9]*.sh
-        do
-          printf '\n\n== %s ==\n' "$t" &&
-          bash $t -q -v -x ||
-          failed=$(($failed+1))
-        done &&
-        if test 0 != $failed
+        if ! t/run_tests -q -v -x
         then
-          mkdir ../failed &&
-          tar czf ../failed/failed.tar.gz .
+          mkdir failed &&
+          tar czf failed/failed.tar.gz t
           exit 1
         fi
     - name: upload failed tests' directories

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ build:
 	@echo Nothing to do: filter-repo is a script which needs no compilation.
 
 test:
-	cd t && time ./run_coverage
+	time t/run_coverage
 
 # fixup_locale might matter once we actually have translations, but right now
 # we don't.  It might not even matter then, because python has a fallback podir.

--- a/t/run_coverage
+++ b/t/run_coverage
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -eu
+
 orig_dir=$(cd $(dirname $0) && pwd -P)
 tmpdir=$(mktemp -d)
 
@@ -17,7 +19,11 @@ EOF
 export COVERAGE_PROCESS_START=$tmpdir/.coveragerc
 export PYTHONPATH=$tmpdir:
 
+# Produce a coverage report, even if the tests fail
+set +e
 $orig_dir/run_tests
+exitcode=$?
+set -e
 
 cd $tmpdir
 coverage3 combine
@@ -25,3 +31,5 @@ coverage3 html -d $orig_dir/report
 coverage3 report -m
 cd $orig_dir
 rm -rf $tmpdir
+
+exit $exitcode

--- a/t/run_coverage
+++ b/t/run_coverage
@@ -16,12 +16,8 @@ EOF
 
 export COVERAGE_PROCESS_START=$tmpdir/.coveragerc
 export PYTHONPATH=$tmpdir:
-# We pretend filenames are unicode for two reasons: (1) because it exercises
-# more code, and (2) this setting will detect accidental use of unicode strings
-# for file/directory names when it should always be bytestrings.
-export PRETEND_UNICODE_ARGS=1
 
-ls t939*.sh | xargs -n 1 bash
+$orig_dir/run_tests
 
 cd $tmpdir
 coverage3 combine

--- a/t/run_tests
+++ b/t/run_tests
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eu
 
 cd $(dirname $0)
 
@@ -7,4 +8,9 @@ cd $(dirname $0)
 # for file/directory names when it should always be bytestrings.
 export PRETEND_UNICODE_ARGS=1
 
-ls t939*.sh | xargs -n 1 bash
+failed=0
+
+for test in t939*.sh; do
+	./$test || failed=1
+done
+exit $failed

--- a/t/run_tests
+++ b/t/run_tests
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+cd $(dirname $0)
+
+# We pretend filenames are unicode for two reasons: (1) because it exercises
+# more code, and (2) this setting will detect accidental use of unicode strings
+# for file/directory names when it should always be bytestrings.
+export PRETEND_UNICODE_ARGS=1
+
+ls t939*.sh | xargs -n 1 bash

--- a/t/run_tests
+++ b/t/run_tests
@@ -3,14 +3,25 @@ set -eu
 
 cd $(dirname $0)
 
+# Put git_filter_repo.py on the front of PYTHONPATH
+export PYTHONPATH="$PWD/..${PYTHONPATH:+:$PYTHONPATH}"
+
 # We pretend filenames are unicode for two reasons: (1) because it exercises
 # more code, and (2) this setting will detect accidental use of unicode strings
 # for file/directory names when it should always be bytestrings.
 export PRETEND_UNICODE_ARGS=1
 
+export TEST_SHELL_PATH=/bin/sh
+
 failed=0
 
-for test in t939*.sh; do
-	./$test || failed=1
+for t in t[0-9]*.sh
+do
+  printf '\n\n== %s ==\n' "$t"
+  bash $t "$@" || failed=$(($failed+1))
 done
-exit $failed
+
+if [ 0 -lt $failed ]
+then
+  exit 1
+fi


### PR DESCRIPTION
There are currently 2 test runners: github workflows, and `t/run_coverage`. The github one isn't useful outside of github workflows, and run_coverage doesn't usefully report failures, and mandates running coverage reports.

This combines both into one, `t/run_tests`, that `t/run_coverage` and the github workflows can both use. They all should now exit non-zero if a test fails.