### PR TITLE
Fix bug in --path-rename argument without colon

### DIFF
--- a/git-filter-repo
+++ b/git-filter-repo
@@ -1622,7 +1622,10 @@ class FilteringOptions(object):
       if suffix.startswith('rename'):
         mod_type = 'rename'
         match_type = option_string[len('--path-rename-'):] or 'match'
-        values = values.split(b':', 1)
+        values = values.split(b':')
+        if len(values) != 2:
+          raise SystemExit(_("Error: --path-rename expects one colon in its"
+                             " argument: <old_name:new_name>."))
         if values[0] and values[1] and not (
            values[0].endswith(b'/') == values[1].endswith(b'/')):
           raise SystemExit(_("Error: With --path-rename, if OLD_NAME and "


### PR DESCRIPTION
When `git filter-repo --path-rename foo` is given, and `foo` does not have a colon, an exception with the following stack trace crashes the program.

```
  File "/usr/local/bin/git-filter-repo", line 1626, in __call__
    if values[0] and values[1] and not (
IndexError: list index out of range
```

This commit fixes the bug, and also checks against the user giving more than one colon in the argument (that would probably indicate some kind of mistake).