### PR TITLE
Improve installation documentation for Windows users

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -17,6 +17,19 @@ no interest in doing so); https://repology.org tracks who packages
 these versions.
 
 
+# Notes for Windows Users
+
+It seems that the default python on Windows is not fully functional,
+and windows might not allow executing python scripts by default.  See
+[issue 124](https://github.com/newren/git-filter-repo/issues/124),
+[issue 36](https://github.com/newren/git-filter-repo/issues/36), and
+[this git mailing list
+thread](https://lore.kernel.org/git/nycvar.QRO.7.76.6.2004251610300.18039@tvgsbejvaqbjf.bet/)
+for details and workarounds.  I believe that Windows users installing
+git-filter-repo via Scoop will be okay, but those using a manual
+installation or pip install may run into these issues.
+
+
 # Manual Installation
 
 filter-repo only consists of a few files that need to be installed:
@@ -70,14 +83,26 @@ filter-repo only consists of a few files that need to be installed:
     instructions regardless of whether the html version of help is
     installed.
 
-So, installation might look something like
-```
-cp -a git-filter-repo $(git --exec-path)
-cp -a git-filter-repo.1 $(git --man-path)/man1
-cp -a git-filter-repo.html $(git --html-path)
-ln -s $(git --exec-path)/git-filter-repo \
-    $(python -c "import site; print(site.getsitepackages()[-1])")/git_filter_repo.py
-```
+So, installation might look something like the following:
+
+1. If you don't have the necessary documentation files (because you
+   are installing from a clone of filter-repo instead of from a
+   tarball) then you can first run:
+
+   `make snag_docs`
+
+   (which just copies the generated documentation files from the
+   `docs` branch)
+
+2. Run the following
+
+   ```
+   cp -a git-filter-repo $(git --exec-path)
+   cp -a git-filter-repo.1 $(git --man-path)/man1
+   cp -a git-filter-repo.html $(git --html-path)
+   ln -s $(git --exec-path)/git-filter-repo \
+       $(python -c "import site; print(site.getsitepackages()[-1])")/git_filter_repo.py
+   ```
 
 # Installation via [pip](https://pip.pypa.io/)
 
@@ -85,6 +110,12 @@ For those who prefer to install python packages via pip, you merely need
 to run:
 
     $ pip3 install git-filter-repo
+
+However, the place where pip places that package might not be in your
+$PATH (thus requiring you to manually update your $PATH afterwards),
+and on windows the pip install might not take care of python-specific
+issues for you (see "Notes for Windows Users", above).  As such,
+installation via package managers is recommended instead.
 
 
 # Installation via Makefile

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -19,8 +19,33 @@ these versions.
 
 # Notes for Windows Users
 
-It seems that the default python on Windows is not fully functional,
-and windows might not allow executing python scripts by default.  See
+If you don't do a full blown Python web development on Windows the
+best way to install git-filter-repo is to use Python and pip from
+[Microsoft
+Store](https://docs.microsoft.com/en-us/windows/python/beginners).
+Follow these simple steps:
+
+1. Install Python from Microsoft Store.
+2. Run `pip install git-filter-repo` from the Windows Command Prompt.
+3. Copy git-filter-repo file from
+    *%LOCALAPPDATA%\Packages\PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0\LocalCache\local-packages\Python39\Scripts*
+    to the directory pointed to by `git --exec-path`,
+
+    or
+
+    add
+    *%LOCALAPPDATA%\Packages\PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0\LocalCache\local-packages\Python39\Scripts*
+    to you PATH environment variable.
+    
+    The folder above could be different depending on your Python's
+    version.
+4. Change first line of the git-filter-repo script to
+`#!\python.exe`.
+
+If you have Python installed via
+[WSL](https://docs.microsoft.com/en-us/windows/python/web-frameworks)
+or from official [Python for Windows
+installer](https://www.python.org/downloads/windows/) see
 [issue 124](https://github.com/newren/git-filter-repo/issues/124),
 [issue 36](https://github.com/newren/git-filter-repo/issues/36), and
 [this git mailing list

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -39,8 +39,6 @@ Follow these simple steps:
     
     The folder above could be different depending on your Python's
     version.
-4. Change first line of the git-filter-repo script to
-`#!\python.exe`.
 
 If you have Python installed via
 [WSL](https://docs.microsoft.com/en-us/windows/python/web-frameworks)

--- a/git-filter-repo
+++ b/git-filter-repo
@@ -1862,7 +1862,7 @@ EXAMPLES
                "part of git history, historical versions of the file will "
                "be ignored; only the current contents are consulted."))
     people.add_argument('--use-mailmap', dest='mailmap',
-        action='store_const', const='.mailmap',
+        action='store_const', const=b'.mailmap',
         help=_("Same as: '--mailmap .mailmap' "))
 
     parents = parser.add_argument_group(title=_("Parent rewriting"))


### PR DESCRIPTION
Since Windows do allow to install Python more easily these days and takes care of most PATH stuff, use recommendations from Microsoft.

The only hiccup is that Git for Windows cannot parse get-filter-repo SHEBANG value when the script is installed via pip. That value is very long by default. Changing it to #!\python.exe solves the issue.

Tested under clean installation of Windows 10 Enterprise version 20H2.