### PR TITLE
Windows fixes

### DIFF
--- a/contrib/filter-repo-demos/lint-history
+++ b/contrib/filter-repo-demos/lint-history
@@ -114,7 +114,7 @@ def lint_with_real_filenames(commit, metadata):
         f.write(contents_plus_newline[:-1])
 
       # Lint the file
-      subprocess.check_call(lint_args.command + [filename])
+      subprocess.check_call(lint_args.command + [filename.decode('utf-8')])
 
       # Get the new contents
       with open(filename, "rb") as f:

--- a/git-filter-repo
+++ b/git-filter-repo
@@ -1622,7 +1622,10 @@ class FilteringOptions(object):
       if suffix.startswith('rename'):
         mod_type = 'rename'
         match_type = option_string[len('--path-rename-'):] or 'match'
-        values = values.split(b':', 1)
+        values = values.split(b':')
+        if len(values) != 2:
+          raise SystemExit(_("Error: --path-rename expects one colon in its"
+                             " argument: <old_name:new_name>."))
         if values[0] and values[1] and not (
            values[0].endswith(b'/') == values[1].endswith(b'/')):
           raise SystemExit(_("Error: With --path-rename, if OLD_NAME and "

--- a/git-filter-repo
+++ b/git-filter-repo
@@ -1862,7 +1862,7 @@ EXAMPLES
                "part of git history, historical versions of the file will "
                "be ignored; only the current contents are consulted."))
     people.add_argument('--use-mailmap', dest='mailmap',
-        action='store_const', const='.mailmap',
+        action='store_const', const=b'.mailmap',
         help=_("Same as: '--mailmap .mailmap' "))
 
     parents = parser.add_argument_group(title=_("Parent rewriting"))

--- a/t/t9391-filter-repo-lib-usage.sh
+++ b/t/t9391-filter-repo-lib-usage.sh
@@ -4,7 +4,14 @@ test_description='Usage of git-filter-repo as a library'
 . ./test-lib.sh
 
 # for git_filter_repo.py import
-export PYTHONPATH=$(dirname $TEST_DIRECTORY):$PYTHONPATH
+case "$(uname -s)" in
+MINGW*|MSYS)
+	export PYTHONPATH=$(cygpath -am $TEST_DIRECTORY/..)\;$PYTHONPATH
+	;;
+*)
+	export PYTHONPATH=$(dirname $TEST_DIRECTORY):$PYTHONPATH
+	;;
+esac
 # Avoid writing git_filter_repo.pyc file
 export PYTHONDONTWRITEBYTECODE=1
 export CONTRIB_DIR=$TEST_DIRECTORY/../contrib/filter-repo-demos


### PR DESCRIPTION
I [finally got Git Bash to accept the Windows Store version of Python](https://github.com/msys2/msys2-runtime/pull/27), so naturally I wanted to verify that the test suite works, but that was not so, funnily enough.

With these two fixes, I can run t9391 successfully in Git for Windows v2.31.1.