### PR TITLE
git-filter-repo.txt: fix typo in paths-from-file example

### DIFF
--- a/Documentation/git-filter-repo.txt
+++ b/Documentation/git-filter-repo.txt
@@ -761,7 +761,7 @@ git filter-repo --paths-from-file stuff-i-want.txt
 
 to get a repo containing only the toplevel README.md file, the guides/
 and tools/releases/ directories, all python files, files whose name
-was of the form YYYY.MM-DD.txt at least two subdirectories deep, and
+was of the form YYYY-MM-DD.txt at least two subdirectories deep, and
 would rename tools/ to scripts/ and rename files like foo/bar/baz.text
 to bar/foo/baz.txt.  Note the special line prefixes of `glob:` and
 `regex:` and the special string `==>` denoting renames.


### PR DESCRIPTION
The "Filtering based on many paths" section includes this code snippet,
```
# An example that is like --path-regex:
regex:^.*/.*/[0-9]{4}-[0-9]{2}-[0-9]{2}.txt$
```
and this  text, 

> files whose name was of the form YYYY.MM-DD.txt at least two subdirectories deep

Update the text to YYYY-MM-DD.txt to match the regex in the code snippet.