### PR TITLE
Fix "fatal: this operation must be run in a work tree" error when running bfg-ish

### DIFF
--- a/contrib/filter-repo-demos/bfg-ish
+++ b/contrib/filter-repo-demos/bfg-ish
@@ -371,6 +371,7 @@ class BFG_ish:
     bfg_args = self.parse_options()
     preserve_refs = self.get_preservation_info(bfg_args.preserve_ref_tips)
 
+    os.environ["GIT_WORK_TREE"] = os.path.abspath(os.fsdecode(bfg_args.repo))
     os.chdir(bfg_args.repo)
     bfg_args.delete_files = java_to_fnmatch_glob(bfg_args.delete_files)
     bfg_args.delete_folders = java_to_fnmatch_glob(bfg_args.delete_folders)


### PR DESCRIPTION
Hardcoding GIT_WORK_TREE to GIT_DIR seems to be a sane way to silence the error.  Please review.

Fixes #240.

Signed-off-by: 林博仁(Buo-ren Lin) <Buo.Ren.Lin@gmail.com>