### PR TITLE
filter-repo: Use author date instead of commit date in --analyze

### DIFF
--- a/git-filter-repo
+++ b/git-filter-repo
@@ -2319,7 +2319,7 @@ class RepoAnalyze(object):
     commit_parse_progress = ProgressWriter()
     num_commits = 0
     cmd = ('git rev-list --topo-order --reverse {}'.format(' '.join(args.refs)) +
-           ' | git diff-tree --stdin --always --root --format=%H%n%P%n%cd' +
+           ' | git diff-tree --stdin --always --root --format=%H%n%P%n%ad' +
            ' --date=short -M -t -c --raw --combined-all-paths')
     dtp = subproc.Popen(cmd, shell=True, bufsize=-1, stdout=subprocess.PIPE)
     f = dtp.stdout


### PR DESCRIPTION
The date displayed in the analysis is the *commit date*. This date is often less accurate when analyzing "when" something happened, since it will be reset by things like cherry-picks, rebase etc. 

In my experience, the *author date* provides a more reliable indication.

However, I must concede that I'm not an expert on the subject. It could very well be that the *commit date* is a lot more reasonable. In my particular case however, the *commit date* is effectively useless as it presents several years of changes having occurred within the last two days.