### PR TITLE
Calculate the version from the module, not the entry_point

### DIFF
--- a/git-filter-repo
+++ b/git-filter-repo
@@ -1597,7 +1597,7 @@ class GitUtils(object):
 
   @staticmethod
   def print_my_version():
-    with open(sys.argv[0], 'br') as f:
+    with open(__file__, 'br') as f:
       contents = f.read()
     # If people replaced @@LOCALEDIR@@ string to point at their local
     # directory, undo it so we can get original source version.


### PR DESCRIPTION
When git-filter-repo is installed, sys.argv[0] will be an entry-point stub, not the relevant Python module.