### PR TITLE
Fix issue 276 binary blob detection

### DIFF
--- a/git-filter-repo
+++ b/git-filter-repo
@@ -3261,8 +3261,10 @@ class RepoFilter(object):
     if blob.original_id in self._args.strip_blobs_with_ids:
       blob.skip()
 
-    if self._args.replace_text and \
-       not any(x == b"0" for x in blob.data[0:8192]):
+    if ( self._args.replace_text
+        # not (if blob contains zero byte in the first 8Kb, that is, if blob is binary data)
+        and not b"\0" in blob.data[0:8192]
+    ):
       for literal, replacement in self._args.replace_text['literals']:
         blob.data = blob.data.replace(literal, replacement)
       for regex,   replacement in self._args.replace_text['regexes']:

--- a/t/t9390-filter-repo.sh
+++ b/t/t9390-filter-repo.sh
@@ -850,6 +850,87 @@ test_expect_success '--replace-text all options' '
 	)
 '
 
+test_expect_success '--replace-text binary zero_byte-0_char' '
+	(
+		set -e
+		set -u
+		REPO=replace-text-detect-binary
+		FILE=mangle.bin
+		OLD_STR=replace-from
+		NEW_STR=replace-with
+		# used with printf, contains a zero byte and a "0" character, binary
+		OLD_CONTENT_FORMAT="${OLD_STR}\\0${OLD_STR}\\n0\\n"
+		# expect content unchanged due to binary
+		NEW_CONTENT_FORMAT="${OLD_CONTENT_FORMAT}"
+
+		rm -rf "${REPO}"
+		git init "${REPO}"
+		cd "${REPO}"
+		echo "${OLD_STR}==>${NEW_STR}" >../replace-rules
+		printf "${NEW_CONTENT_FORMAT}" > ../expect
+		printf "${OLD_CONTENT_FORMAT}" > "${FILE}"
+		git add "${FILE}"
+		git commit -m 'test'
+		git filter-repo --force --replace-text ../replace-rules
+
+		test_cmp ../expect "${FILE}"
+	)
+'
+
+test_expect_success '--replace-text binary zero_byte-no_0_char' '
+	(
+		set -e
+		set -u
+		REPO=replace-text-detect-binary
+		FILE=mangle.bin
+		OLD_STR=replace-from
+		NEW_STR=replace-with
+		# used with printf, contains a zero byte but no "0" character, binary
+		OLD_CONTENT_FORMAT="${OLD_STR}\\0${OLD_STR}\\n"
+		# expect content unchanged due to binary
+		NEW_CONTENT_FORMAT="${OLD_CONTENT_FORMAT}"
+
+		rm -rf "${REPO}"
+		git init "${REPO}"
+		cd "${REPO}"
+		echo "${OLD_STR}==>${NEW_STR}" >../replace-rules
+		printf "${NEW_CONTENT_FORMAT}" > ../expect
+		printf "${OLD_CONTENT_FORMAT}" > "${FILE}"
+		git add "${FILE}"
+		git commit -m 'test'
+		git filter-repo --force --replace-text ../replace-rules
+
+		test_cmp ../expect "${FILE}"
+	)
+'
+
+test_expect_success '--replace-text text-file no_zero_byte-zero_char' '
+	(
+		set -e
+		set -u
+		REPO=replace-text-detect-binary
+		FILE=mangle.bin
+		OLD_STR=replace-from
+		NEW_STR=replace-with
+		# used with printf, contains no zero byte but contains a "0" character, text
+		OLD_CONTENT_FORMAT="${OLD_STR}\\n${OLD_STR}\\n"
+		# expect content changed due to text
+		NEW_CONTENT_FORMAT="${NEW_STR}\\n${NEW_STR}\\n"
+
+		rm -rf "${REPO}"
+		git init "${REPO}"
+		cd "${REPO}"
+		echo "${OLD_STR}==>${NEW_STR}" >../replace-rules
+		printf "${NEW_CONTENT_FORMAT}" > ../expect
+		printf "${OLD_CONTENT_FORMAT}" > "${FILE}"
+		git add "${FILE}"
+		git commit -m 'test'
+		git filter-repo --force --replace-text ../replace-rules
+
+		test_cmp ../expect "${FILE}"
+	)
+'
+
 test_expect_success '--strip-blobs-bigger-than' '
 	setup_analyze_me &&
 	(


### PR DESCRIPTION
Hi,

Please consider a fix and tests for issue 276 re binary blob detection not working and --text-replace replaces text in binary files which is not intended.

Thanks.