### PR TITLE
Changing order of commit msg update

### DIFF
--- a/git-filter-repo
+++ b/git-filter-repo
@@ -3400,10 +3400,6 @@ class RepoFilter(object):
     commit.file_changes = [v for k,v in sorted(new_file_changes.items())]
 
   def _tweak_commit(self, commit, aux_info):
-    # Change the commit message according to callback
-    if not self._args.preserve_commit_hashes:
-      commit.message = self._hash_re.sub(self._translate_commit_hash,
-                                         commit.message)
     if self._args.replace_message:
       for literal, replacement in self._args.replace_message['literals']:
         commit.message = commit.message.replace(literal, replacement)
@@ -3411,6 +3407,11 @@ class RepoFilter(object):
         commit.message = regex.sub(replacement, commit.message)
     if self._message_callback:
       commit.message = self._message_callback(commit.message)
+
+    # Change the commit message according to callback
+    if not self._args.preserve_commit_hashes:
+      commit.message = self._hash_re.sub(self._translate_commit_hash,
+                                         commit.message)
 
     # Change the author & committer according to mailmap rules
     args = self._args

--- a/git-filter-repo
+++ b/git-filter-repo
@@ -1964,6 +1964,10 @@ EXAMPLES
     location.add_argument('--target', type=os.fsencode,
         help=_("Git repository to overwrite with filtered history"))
 
+    order = parser.add_argument_group(title=_("Ordering of commits"))
+    order.add_argument('--date-order', action='store_true',
+        help=_("Sort the commits by date of creation."))
+
     misc = parser.add_argument_group(title=_("Miscellaneous options"))
     misc.add_argument('--help', '-h', action='store_true',
         help=_("Show this help message and exit."))
@@ -3662,11 +3666,14 @@ class RepoFilter(object):
       if self._args.preserve_commit_encoding is not None: # pragma: no cover
         reencode = 'no' if self._args.preserve_commit_encoding else 'yes'
         extra_flags.append('--reencode='+reencode)
+      if self._args.date_order:
+        extra_flags.append('--date-order')
       location = ['-C', self._args.source] if self._args.source else []
       fep_cmd = ['git'] + location + ['fast-export', '--show-original-ids',
                  '--signed-tags=strip', '--tag-of-filtered-object=rewrite',
                  '--fake-missing-tagger', '--reference-excluded-parents'
                  ] + extra_flags + self._args.refs
+
       self._fep = subproc.Popen(fep_cmd, bufsize=-1, stdout=subprocess.PIPE)
       self._input = self._fep.stdout
       if self._args.dry_run or self._args.debug:


### PR DESCRIPTION
Currently the order of execution is:
1. Update the  `SHA` references in the messages
2. Execute the `message-callback` to update the message
3. Added an option `--order-by-date` to order commits by date rather than the default `topological` sort.


While adding `SHA references` in a commit message using `message-callback`, the references were not getting updated and were pointing to old commit `SHA`. 
So I changed the order and now it first executes the `message-callback` and then updates the `reference`.

This is a contribution from [Ribose](https://www.ribose.com) ([riboseinc](https://github.com/riboseinc)).