### PR TITLE
allow git-filter-repo clean-ignore args forwarding

### DIFF
--- a/contrib/filter-repo-demos/clean-ignore
+++ b/contrib/filter-repo-demos/clean-ignore
@@ -18,6 +18,7 @@ near the top of git-filter-repo.
 import argparse
 import os
 import subprocess
+import sys
 try:
   import git_filter_repo as fr
 except ImportError:
@@ -65,7 +66,14 @@ class CheckIgnores:
     commit.file_changes = [x for x in commit.file_changes
                            if x.filename not in bad]
 
-checker = CheckIgnores()
-args = fr.FilteringOptions.default_options()
-filter = fr.RepoFilter(args, commit_callback=checker.skip_ignores)
-filter.run()
+
+def main():
+  checker = CheckIgnores()
+  args = fr.FilteringOptions.default_options()
+  filter = fr.RepoFilter(args, commit_callback=checker.skip_ignores)
+  filter.run()
+  
+
+if __name__ == '__main__':
+  main()
+

--- a/contrib/filter-repo-demos/clean-ignore
+++ b/contrib/filter-repo-demos/clean-ignore
@@ -69,7 +69,7 @@ class CheckIgnores:
 
 def main():
   checker = CheckIgnores()
-  args = fr.FilteringOptions.default_options()
+  args = fr.FilteringOptions.parse_args(sys.argv[1:])
   filter = fr.RepoFilter(args, commit_callback=checker.skip_ignores)
   filter.run()
   


### PR DESCRIPTION
This allows the user to provide further argument parameters to `git-filter-repo` when running `clean-ignore`. A common example of when this is needed is when running `clean-ignore` on a repo not freshly cloned, causing below error. 
```
Aborting: Refusing to destructively overwrite repo history since
this does not look like a fresh clone.
```

Furthermore, I add the `git-clean-ignore` naming to allow git's auto-detection of the dash name to integrate it as sub-command automatically. 

With these change, it is possible to call as follows:
```shell
git clean-ignore --force
```