### PR TITLE
Fix crash when filtering unrelated histories by refs

### DIFF
--- a/git-filter-repo
+++ b/git-filter-repo
@@ -3458,7 +3458,7 @@ class RepoFilter(object):
     # to the new first parent
     if parents and old_1st_parent != parents[0]:
       commit.file_changes = GitUtils.get_file_changes(self._repo_working_dir,
-                                                      ID_TO_HASH[parents[0]],
+                                                      ID_TO_HASH.get(parents[0], parents[0]),
                                                       commit.original_id)
       orig_file_changes = set(commit.file_changes)
       self._filter_files(commit)


### PR DESCRIPTION
This is a sort of weird condition.

Consider repository `main-repo`, into which, at some point, another repository `side-repo` was merged via `--allow-unrelated-histories`. `main-repo` now has two root commits and two histories that converge at some point.
Next, pick a commit from `side-repo`'s own history, tag it with `side-tag` for convenience.

If you want to filter by `--refs=side-tag..HEAD`, for example, i.e., the selection starts inside `side-repo`'s history, then the output from `fast-export` is not sorted ideally. I forget the details right now, it made sense at the time ... in any case, the result is that an entry in `parents` can be an untranslated commit hash instead of ID.

So line 3461 will fail because `ID_TO_HASH[parent]` does not exist.

Fortunately we don't actually care because `get_file_changes` _wants_ a commit hash, so it's sufficient to use the raw entry.