### PR TITLE
Makefile: add support for DESTDIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,10 +34,11 @@ Documentation/html/git-filter-repo.html:
 	git show origin/docs:html/git-filter-repo.html >Documentation/html/git-filter-repo.html
 
 install: snag_docs #fixup_locale
-	cp -a git-filter-repo "$(bindir)/"
+	install -Dm0755 git-filter-repo "$(bindir)/git-filter-repo"
+	install -dm0755 "$(pythondir)"
 	ln -sf "$(bindir)/git-filter-repo" "$(pythondir)/git_filter_repo.py"
-	cp -a Documentation/man1/git-filter-repo.1 "$(mandir)/man1/git-filter-repo.1"
-	cp -a Documentation/html/git-filter-repo.html "$(htmldir)/git-filter-repo.html"
+	install -Dm0644 Documentation/man1/git-filter-repo.1 "$(mandir)/man1/git-filter-repo.1"
+	install -Dm0644 Documentation/html/git-filter-repo.html "$(htmldir)/git-filter-repo.html"
 	if which mandb > /dev/null; then mandb; fi
 
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 # A bunch of installation-related paths people can override on the command line
+DESTDIR = /
 prefix = $(HOME)
 bindir = $(prefix)/libexec/git-core
 localedir = $(prefix)/share/locale
@@ -34,11 +35,11 @@ Documentation/html/git-filter-repo.html:
 	git show origin/docs:html/git-filter-repo.html >Documentation/html/git-filter-repo.html
 
 install: snag_docs #fixup_locale
-	install -Dm0755 git-filter-repo "$(bindir)/git-filter-repo"
-	install -dm0755 "$(pythondir)"
-	ln -sf "$(bindir)/git-filter-repo" "$(pythondir)/git_filter_repo.py"
-	install -Dm0644 Documentation/man1/git-filter-repo.1 "$(mandir)/man1/git-filter-repo.1"
-	install -Dm0644 Documentation/html/git-filter-repo.html "$(htmldir)/git-filter-repo.html"
+	install -Dm0755 git-filter-repo "$(DESTDIR)/$(bindir)/git-filter-repo"
+	install -dm0755 "$(DESTDIR)/$(pythondir)"
+	ln -sf "$(bindir)/git-filter-repo" "$(DESTDIR)/$(pythondir)/git_filter_repo.py"
+	install -Dm0644 Documentation/man1/git-filter-repo.1 "$(DESTDIR)/$(mandir)/man1/git-filter-repo.1"
+	install -Dm0644 Documentation/html/git-filter-repo.html "$(DESTDIR)/$(htmldir)/git-filter-repo.html"
 	if which mandb > /dev/null; then mandb; fi
 
 


### PR DESCRIPTION
Packaging `git-filter-repo` is a challenge, as the Makefile install target is mostly geared toward installing it on the local system. One reason is because the Makefile does not support `DESTDIR`. Another reason is that because it uses `cp`, all parent directories must already exist.

This pull request addresses both these issues.