### PR TITLE
Fix path of git-filter-repo.(1|html)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -118,8 +118,8 @@ So, installation might look something like the following:
 
    ```
    cp -a git-filter-repo $(git --exec-path)
-   cp -a git-filter-repo.1 $(git --man-path)/man1 && mandb
-   cp -a git-filter-repo.html $(git --html-path)
+   cp -a Documentation/man1/git-filter-repo.1 $(git --man-path)/man1 && mandb
+   cp -a Documentation/html/git-filter-repo.html $(git --html-path)
    ln -s $(git --exec-path)/git-filter-repo \
        $(python -c "import site; print(site.getsitepackages()[-1])")/git_filter_repo.py
    ```


### PR DESCRIPTION
Since they are not at the root of the repo but in Documentation/(man1 | html) (the Makefile puts them here and the last releast tarball has them in it too)