### PR TITLE
Correct mailmapping of empty email addresses

### DIFF
--- a/git-filter-repo
+++ b/git-filter-repo
@@ -320,8 +320,8 @@ class MailmapInfo(object):
     for old, new in self.changes.items():
       old_name, old_email = old
       new_name, new_email = new
-      if (not old_email or email.lower() == old_email.lower()) and (
-          name  == old_name or not old_name):
+      if (old_email is None or email.lower() == old_email.lower()) and (
+          name == old_name or not old_name):
         return (new_name or name, new_email or email)
     return (name, email)
 


### PR DESCRIPTION
Consider an example repo with 2 commits:
- Commit A by `User <some@email>`
- Commit B by `User <>` (the email field is left empty)

and running `git filter-repo --mailmap f` where `f` contains:
```
New user <new@email> <>
```

**Expected behaviour:** The author of commit B is updated to the new name and email address while commit A is unchanged. This is the behaviour observed when using a Git `.mailmap` file with the same contents. 

**Current behaviour:** Both commits A and B are modified to the new user and email. 

This happens because `not old_email` doesn't distinguish between `None` and an empty string (which is what gets matched by `<>`). This PR changes that to an `is None` check. 