### PR TITLE
Update expected test data for git 2.35

### DIFF
--- a/t/t9390/less-empty-keepme
+++ b/t/t9390/less-empty-keepme
@@ -2,33 +2,33 @@ feature done
 reset refs/heads/master
 commit refs/heads/master
 mark :1
-author Full Name <user@organization.tld> 1000020000 +0100
-committer Full Name <user@organization.tld> 1000020000 +0100
-data 2
-C
-
-commit refs/heads/master
-mark :2
-author Full Name <user@organization.tld> 1000030000 +0100
-committer Full Name <user@organization.tld> 1000030000 +0100
-data 2
-D
-from :1
-
-reset refs/heads/master
-commit refs/heads/master
-mark :3
 author Full Name <user@organization.tld> 1000000000 +0100
 committer Full Name <user@organization.tld> 1000000000 +0100
 data 2
 A
 
 commit refs/heads/master
-mark :4
+mark :2
 author Full Name <user@organization.tld> 1000010000 +0100
 committer Full Name <user@organization.tld> 1000010000 +0100
 data 2
 B
+from :1
+
+reset refs/heads/master
+commit refs/heads/master
+mark :3
+author Full Name <user@organization.tld> 1000020000 +0100
+committer Full Name <user@organization.tld> 1000020000 +0100
+data 2
+C
+
+commit refs/heads/master
+mark :4
+author Full Name <user@organization.tld> 1000030000 +0100
+committer Full Name <user@organization.tld> 1000030000 +0100
+data 2
+D
 from :3
 
 blob
@@ -42,8 +42,8 @@ author Full Name <user@organization.tld> 1000040000 +0100
 committer Full Name <user@organization.tld> 1000040000 +0100
 data 29
 E: Merge commit 'D' into 'B'
-from :4
-merge :2
+from :2
+merge :4
 M 100644 :5 keepme
 
 commit refs/heads/master
@@ -68,8 +68,8 @@ author Full Name <user@organization.tld> 1000050000 +0100
 committer Full Name <user@organization.tld> 1000050000 +0100
 data 29
 F: Merge commit 'D' into 'B'
-from :4
-merge :2
+from :2
+merge :4
 
 blob
 mark :10

--- a/t/t9390/more-empty-keepme
+++ b/t/t9390/more-empty-keepme
@@ -2,29 +2,29 @@ feature done
 blob
 mark :1
 data 10
-keepme v2
+keepme v1
 
 reset refs/heads/master
 commit refs/heads/master
 mark :2
-author Full Name <user@organization.tld> 1000080000 +0100
-committer Full Name <user@organization.tld> 1000080000 +0100
-data 2
-I
+author Full Name <user@organization.tld> 1000040000 +0100
+committer Full Name <user@organization.tld> 1000040000 +0100
+data 29
+E: Merge commit 'D' into 'B'
 M 100644 :1 keepme
 
 blob
 mark :3
 data 10
-keepme v1
+keepme v2
 
 reset refs/heads/master
 commit refs/heads/master
 mark :4
-author Full Name <user@organization.tld> 1000040000 +0100
-committer Full Name <user@organization.tld> 1000040000 +0100
-data 29
-E: Merge commit 'D' into 'B'
+author Full Name <user@organization.tld> 1000080000 +0100
+committer Full Name <user@organization.tld> 1000080000 +0100
+data 2
+I
 M 100644 :3 keepme
 
 commit refs/heads/master
@@ -33,7 +33,7 @@ author Full Name <user@organization.tld> 1000090000 +0100
 committer Full Name <user@organization.tld> 1000090000 +0100
 data 29
 J: Merge commit 'I' into 'H'
-from :4
-merge :2
+from :2
+merge :4
 
 done


### PR DESCRIPTION
Commit order from `fast-export --first-parent` has changed in git 2.35, see https://github.com/git/git/commit/726a228dfb19fae8befa0f209436f8fae7919a58

This will break the same tests on older git releases. I can't see an easy mechanism to skip these tests on older versions or carry multiple expected test outputs.

Fixes: #344