### PR TITLE
[doc] correct link to mailmap manual

### DIFF
--- a/Documentation/git-filter-repo.txt
+++ b/Documentation/git-filter-repo.txt
@@ -206,7 +206,7 @@ Filtering of names & emails (see also --name-callback and --email-callback)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 --mailmap <filename>::
-	Use specified mailmap file (see linkgit:git-shortlog[1] for details
+	Use specified mailmap file (see linkgit:git-mailmap[5] for details
 	on the format) when rewriting author, committer, and tagger names
 	and emails. If the specified file is part of git history,
 	historical versions of the file will be ignored; only the current

--- a/git-filter-repo
+++ b/git-filter-repo
@@ -1875,7 +1875,7 @@ EXAMPLES
                                                "and --email-callback)"))
     people.add_argument('--mailmap', dest='mailmap', metavar='FILENAME',
         type=os.fsencode,
-        help=_("Use specified mailmap file (see git-shortlog(1) for "
+        help=_("Use specified mailmap file (see git-mailmap(5) for "
                "details on the format) when rewriting author, committer, "
                "and tagger names and emails.  If the specified file is "
                "part of git history, historical versions of the file will "


### PR DESCRIPTION
the format of mailmap is explained in git-mailmap(5), not git-shortlog(1).