### PR TITLE
Makefile: abstract out the `install` binary used

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 # A bunch of installation-related paths people can override on the command line
 DESTDIR = /
+INSTALL = install
 prefix = $(HOME)
 bindir = $(prefix)/libexec/git-core
 localedir = $(prefix)/share/locale
@@ -35,11 +36,11 @@ Documentation/html/git-filter-repo.html:
 	git show origin/docs:html/git-filter-repo.html >Documentation/html/git-filter-repo.html
 
 install: snag_docs #fixup_locale
-	install -Dm0755 git-filter-repo "$(DESTDIR)/$(bindir)/git-filter-repo"
-	install -dm0755 "$(DESTDIR)/$(pythondir)"
+	$(INSTALL) -Dm0755 git-filter-repo "$(DESTDIR)/$(bindir)/git-filter-repo"
+	$(INSTALL) -dm0755 "$(DESTDIR)/$(pythondir)"
 	ln -sf "$(bindir)/git-filter-repo" "$(DESTDIR)/$(pythondir)/git_filter_repo.py"
-	install -Dm0644 Documentation/man1/git-filter-repo.1 "$(DESTDIR)/$(mandir)/man1/git-filter-repo.1"
-	install -Dm0644 Documentation/html/git-filter-repo.html "$(DESTDIR)/$(htmldir)/git-filter-repo.html"
+	$(INSTALL) -Dm0644 Documentation/man1/git-filter-repo.1 "$(DESTDIR)/$(mandir)/man1/git-filter-repo.1"
+	$(INSTALL) -Dm0644 Documentation/html/git-filter-repo.html "$(DESTDIR)/$(htmldir)/git-filter-repo.html"
 	if which mandb > /dev/null; then mandb; fi
 
 


### PR DESCRIPTION
Fixes #398