### PR TITLE
Handle tags with no date without blowing up

### DIFF
--- a/git-filter-repo
+++ b/git-filter-repo
@@ -767,7 +767,10 @@ class Tag(_GitElementWithId):
     self.tagger_email = tagger_email
 
     # Store the date
-    self.tagger_date  = tagger_date
+    if tagger_date:
+        self.tagger_date  = tagger_date
+    else:
+        self.tagger_date = b"0 +0000"
 
     # Store the tag message
     self.message = tag_msg
@@ -951,7 +954,7 @@ class FastExportParser(object):
       self._refline_regexes[refline_name] = re.compile(refline_name+b' (.*)\n$')
     self._user_regexes = {}
     for user in (b'author', b'committer', b'tagger'):
-      self._user_regexes[user] = re.compile(user + b' (.*?) <(.*?)> (.*)\n$')
+      self._user_regexes[user] = re.compile(user + b' (.*?) <(.*?)>(?: (.*))?\n$')
 
   def _advance_currentline(self):
     """


### PR DESCRIPTION
In some situations, git-fast-export generates tagger lines with no date, such as:

    tag v1_7_1
    mark :758
    from :592
    original-oid 52e4c981c5ee8c4225316b418775e95dd436b6ef
    tagger Gerrit Pape <pape@smarden.org>
    data 0

This would cause git-filter-repo to fail because the regular expression used to parse user information wouldn't match.

This commit modifies the regular expression so that it user information without a date, and then emit a date of "0 +0000" when writing out tags that have no date.

I'm not sure this is an ideal solution; I think a better solution would be for the tag to inherit the date from the commit to which it points, but that seemed a little more involved and this at least lets filter-repo successfully complete.

Addresses #413
