### PR TITLE
filter-repo: add missing "will" to generated README

### DIFF
--- a/git-filter-repo
+++ b/git-filter-repo
@@ -2491,7 +2491,7 @@ class RepoAnalyze(object):
         files were packed; i.e., without delta-ing or compression.
 
         Both unpacked and packed sizes can be slightly misleading.  Deleting
-        a blob from history not save as much space as the unpacked size,
+        a blob from history will not save as much space as the unpacked size,
         because it is obviously normally stored in packed form.  Also,
         deleting a blob from history may not save as much space as its packed
         size either, because another blob could be stored as a delta against


### PR DESCRIPTION
I considered "may" or "can", but "will" makes more sense to me in context.