### PR TITLE
README: fix typo to clarify design rationale

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,9 +308,9 @@ But this comes with some nasty caveats and limitations:
 # Design rationale behind filter-repo
 
 None of the existing repository filtering tools did what I wanted;
-they all came up short for my needs.  No tool provided any of the
-first eight traits below I wanted, and all failed to provide at least
-one of the last four traits as well:
+they all came up short for my needs. No tool provided any of the
+first eight traits below I wanted, and no tool provided more than
+two of the last four traits either:
 
   1. [Starting report] Provide user an analysis of their repo to help
      them get started on what to prune or rename, instead of expecting


### PR DESCRIPTION
While I am not a big fan of PRs to to fix typos, the README.md `Design Rationale` section has a small typo ("any" instead of "each") that confused me on my first read-through so I added a tiny PR to fix it, since it hinders understanding.

I am assuming that the design rationale was that there were no existing tools which implemented all of the first 8 traits, and none that implemented even a single one of the final four traits. This change just makes that clear (if that was the intended interpretation!).