### PR TITLE
README.md: add basic installation instructions for Ubuntu

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,14 +11,17 @@
 # Pre-requisites
 
 Instructions on this page assume you have already installed both
-[Git](https://git-scm.com) and [Python](https://www.python.org/).
+[Git](https://git-scm.com) and [Python](https://www.python.org/)
+(though the [Notes for Windows Users](#notes-for-windows-users) has
+some tips on Python).
 
 # Simple Installation
 
-All you need to do is download the [git-filter-repo script in this
-repository](git-filter-repo) ([direct link to raw
-file](https://raw.githubusercontent.com/newren/git-filter-repo/main/git-filter-repo)).
-**That's it**.  You're done.
+All you need to do is download one file: the [git-filter-repo script
+in this repository](git-filter-repo) ([direct link to raw
+file](https://raw.githubusercontent.com/newren/git-filter-repo/main/git-filter-repo)),
+making sure to preserve its name (`git-filter-repo`, with no
+extension).  **That's it**.  You're done.
 
 Then you can run any command you want, such as
 
@@ -146,15 +149,17 @@ you'll still need to do that yourself.
 
 Windows likes to make things difficult.  Common and historical issues:
 
-  * [**Non-functional Python
-    stub**](https://github.com/newren/git-filter-repo/issues/36#issuecomment-568933825):
-    Windows apparently ships with a non-functional python.  This can
-    even manifest as [the app
+  * **Non-functional Python stub**: Windows apparently ships with a
+    [non-functional
+    python](https://github.com/newren/git-filter-repo/issues/36#issuecomment-568933825).
+    This can even manifest as [the app
     hanging](https://github.com/newren/git-filter-repo/issues/36) or
     [the system appearing to
     hang](https://github.com/newren/git-filter-repo/issues/312).  Try
-    installing Python from the [Microsoft
-    Store](https://docs.microsoft.com/en-us/windows/python/beginners)
+    installing
+    [Python](https://docs.microsoft.com/en-us/windows/python/beginners)
+    from the [Microsoft
+    Store](https://apps.microsoft.com/store/search?publisher=Python%20Software%20Foundation)
   * **Modifying PATH, making the script executable**: For some reason lots of
     Windows users have a hard time modifying their PATH and/or making scripts
     executable.  You can skip that step by just using

--- a/README.md
+++ b/README.md
@@ -63,25 +63,25 @@ following apply:
 
 # How do I use it?
 
-See the [user
-manual](https://htmlpreview.github.io/?https://github.com/newren/git-filter-repo/blob/docs/html/git-filter-repo.html).
+For comprehensive documentation:
+  * see the [user manual](https://htmlpreview.github.io/?https://github.com/newren/git-filter-repo/blob/docs/html/git-filter-repo.html)
+  * alternative formating of the user manual is available on various
+    external sites
+    ([example](https://www.mankier.com/1/git-filter-repo)), for those
+    that don't like the htmlpreview.github.io layout, though it may
+    only be up-to-date as of the latest release
 
 If you prefer learning from examples:
-  * the [simple example](#simple-example-with-comparisons) below may
-    be of interest
-  * the user manual has an extensive [examples
-section](https://htmlpreview.github.io/?https://github.com/newren/git-filter-repo/blob/docs/html/git-filter-repo.html#EXAMPLES)
   * there is a [cheat sheet for converting filter-branch
     commands](Documentation/converting-from-filter-branch.md#cheat-sheet-conversion-of-examples-from-the-filter-branch-manpage),
     which covers every example from the filter-branch manual
   * there is a [cheat sheet for converting BFG Repo Cleaner
     commands](Documentation/converting-from-bfg-repo-cleaner.md#cheat-sheet-conversion-of-examples-from-bfg),
     which covers every example from the BFG website
-
-External sites also have [alternative formats of the user
-manual](https://www.mankier.com/1/git-filter-repo) available, at least
-for the most recent release.  This also may be beneficial if
-htmlpreview.github.io starts hitting load limits.
+  * the [simple example](#simple-example-with-comparisons) below may
+    be of interest
+  * the user manual has an extensive [examples
+section](https://htmlpreview.github.io/?https://github.com/newren/git-filter-repo/blob/docs/html/git-filter-repo.html#EXAMPLES)
 
 # Why filter-repo instead of other alternatives?
 

--- a/README.md
+++ b/README.md
@@ -44,18 +44,22 @@ filter-repo requires:
 
 # How do I install it?
 
-git-filter-repo is a single-file python script, which was done to make
-installation for basic use on many systems trivial: just place the
-script into your $PATH.
+`git-filter-repo` is a single-file python script, which was done to make
+installation for basic use on many systems trivial: just place that
+file into your $PATH.
 
 See [INSTALL.md](INSTALL.md) for things beyond basic usage or special
-cases.  The more involved instructions are only needed if you
+cases.  The more involved instructions are only needed if one of the
+following apply:
 
-  * are working with a python3 executable named something other than "python3"
-  * want to install documentation (beyond the builtin docs shown with -h)
-  * want to run some of the [contrib](contrib/filter-repo-demos/) examples
-  * want to create your own python filtering scripts using filter-repo as a
-    module/library
+  * you do not find the above comment about trivial installation intuitively
+    obvious
+  * you are working with a python3 executable named something other than
+    "python3"
+  * you want to install documentation (beyond the builtin docs shown with -h)
+  * you want to run some of the [contrib](contrib/filter-repo-demos/) examples
+  * you want to create your own python filtering scripts using filter-repo as
+    a module/library
 
 # How do I use it?
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,59 @@ filter-repo requires:
 
 `git-filter-repo` is a single-file python script, which was done to make
 installation for basic use on many systems trivial: just place that
-file into your $PATH.
+file into your `$PATH`. Example:
+
+### How to install `git filter-repo` on Linux Ubuntu:
+
+```bash
+# --------------------
+# 1. Download it
+# --------------------
+
+# Option 1 [easiest]: download the latest version
+wget https://raw.githubusercontent.com/newren/git-filter-repo/main/git-filter-repo
+
+# OR Option 2: get the latest *released* version.
+# Go here and find the latest release:
+# https://github.com/newren/git-filter-repo/releases
+# Use that release number in the cmds below.
+wget https://github.com/newren/git-filter-repo/releases/download/v2.38.0/git-filter-repo-2.38.0.tar.xz
+# install dependencies
+sudo apt install xz-utils  
+# extract the downloaded archive
+tar -xf git-filter-repo-2.38.0.tar.xz
+# copy out the executable; we'll move it to a directory within our PATH later
+cp git-filter-repo-2.38.0/git-filter-repo .
+
+# --------------------
+# 2. make it executable
+# --------------------
+chmod +x git-filter-repo
+
+# --------------------
+# 3. move it to a dir in your PATH
+# --------------------
+
+# Option 1 [easiest]: make this executable accessible to ALL users
+sudo mv -i git-filter-repo /usr/local/bin
+
+# OR Option 2: make this executable accessible to your user only
+mkdir -p ~/bin
+mv -i git-filter-repo ~/bin 
+# add ~/bin to your path by re-sourcing your `~/.profile` file.
+# This works on Ubuntu if you are using the default ~/.profile file, which can
+# also be found in /etc/skel/.profile, by the way.
+. ~/.profile
+
+# --------------------
+# 4. Done. Now run it.
+# --------------------
+git filter-repo --version       # check the version
+git filter-repo -h              # help menu
+git filter-repo -h | less -RFX  # help menu, viewed in the `less` viewer
+```
+
+### Advanced install
 
 See [INSTALL.md](INSTALL.md) for things beyond basic usage or special
 cases.  The more involved instructions are only needed if one of the


### PR DESCRIPTION
Add basic installation instructions for Ubuntu, as a demonstration for even the most beginner users.

Note: these instructions were first posted here:
https://github.com/rtyley/bfg-repo-cleaner/issues/255#issuecomment-1500711841

Resolves #450 