### PR TITLE
Remove symlink that breaks install on Windows

### DIFF
--- a/git_filter_repo.py
+++ b/git_filter_repo.py
@@ -1,1 +1,0 @@
-git-filter-repo


### PR DESCRIPTION
e.g. Using scoop

See: https://github.com/ScoopInstaller/Scoop/issues/4647:

Fix: #249