### PR TITLE
Minor typos

### DIFF
--- a/Documentation/git-filter-repo.txt
+++ b/Documentation/git-filter-repo.txt
@@ -267,7 +267,7 @@ Generic callback code snippets
 	Python code body for processing names of people; see <<CALLBACKS>>.
 
 --email-callback <function_body>::
-	Python code body for processing emails addresses; see
+	Python code body for processing email addresses; see
 	<<CALLBACKS>>.
 
 --refname-callback <function_body>::

--- a/git-filter-repo
+++ b/git-filter-repo
@@ -1933,7 +1933,7 @@ EXAMPLES
         help=_("Python code body for processing names of people; see "
                "CALLBACKS section below."))
     callback.add_argument('--email-callback', metavar="FUNCTION_BODY_OR_FILE",
-        help=_("Python code body for processing emails addresses; see "
+        help=_("Python code body for processing email addresses; see "
                "CALLBACKS section below."))
     callback.add_argument('--refname-callback', metavar="FUNCTION_BODY_OR_FILE",
         help=_("Python code body for processing refnames; see CALLBACKS "

--- a/git-filter-repo
+++ b/git-filter-repo
@@ -873,7 +873,7 @@ class Alias(_GitElement):
 
   def __init__(self, ref, to_ref):
     _GitElement.__init__(self)
-    # Denote that this is a reset
+    # Denote that this is an alias
     self.type = 'alias'
 
     self.ref = ref
@@ -881,7 +881,7 @@ class Alias(_GitElement):
 
   def dump(self, file_):
     """
-    Write this reset element to a file
+    Write this alias element to a file
     """
     self.dumped = 1
 


### PR DESCRIPTION
Fixed a few minor typos.

'emails addresses' >> 'email addresses'
'reset' >> 'alias' in Alias class

This is the second try incorporating suggestion from #470.