### PR TITLE
fix duplicate setuptools entry point script

### DIFF
--- a/release/setup.cfg
+++ b/release/setup.cfg
@@ -23,10 +23,13 @@ platforms = any
 license = MIT
 
 [options]
-scripts = git-filter-repo
 py_modules = git_filter_repo
 python_requires = >= 3.5
 setup_requires = setuptools_scm
+
+[options.entry_points]
+console_scripts =
+    git-filter-repo = git_filter_repo:main
 
 [bdist_wheel]
 universal = 1

--- a/release/setup.py
+++ b/release/setup.py
@@ -11,11 +11,9 @@ def link_parent(src, target=None):
         pass
 
 
-for f in ['git-filter-repo', 'README.md']:
-    link_parent(f)
+link_parent('README.md')
 
 link_parent('git-filter-repo', 'git_filter_repo.py')
 
 
-setup(use_scm_version=dict(root="..", relative_to=__file__),
-      entry_points={'console_scripts': ['git-filter-repo = git_filter_repo:main']})
+setup(use_scm_version=dict(root="..", relative_to=__file__))


### PR DESCRIPTION
There is a subtle issue when installing from the wheel that's built. By declaring a console_script entry point, when the wheel is installed, a script named `git-filter-repo` is created. At the same time, inside setup.cfg, a script named `git-filter-repo` is declared (and a symlink is created in the release directory). This causes a collision when installing the wheel.

When the wheel is installed using `pip`, the collision is ignored. When the wheel is installed using [installer](https://installer.pypa.io/en/stable/), an error is raised. This PR fixes the issue by removing the script and relying only on the console_script entry point.