### PR TITLE
Allow clean-ignore to run without arguments.

### DIFF
--- a/contrib/filter-repo-demos/clean-ignore
+++ b/contrib/filter-repo-demos/clean-ignore
@@ -69,7 +69,10 @@ class CheckIgnores:
 
 def main():
   checker = CheckIgnores()
-  args = fr.FilteringOptions.parse_args(sys.argv[1:])
+  if sys.argsv[1:]:
+    args = fr.FilteringOptions.parse_args(sys.argv[1:])
+  else:
+    args = fr.FilteringOptions.parse_args(['--force'])
   filter = fr.RepoFilter(args, commit_callback=checker.skip_ignores)
   filter.run()
   

--- a/contrib/filter-repo-demos/clean-ignore
+++ b/contrib/filter-repo-demos/clean-ignore
@@ -69,10 +69,7 @@ class CheckIgnores:
 
 def main():
   checker = CheckIgnores()
-  if sys.argsv[1:]:
-    args = fr.FilteringOptions.parse_args(sys.argv[1:])
-  else:
-    args = fr.FilteringOptions.parse_args(['--force'])
+  args = fr.FilteringOptions.parse_args(sys.argv[1:] if sys.argv[1:] else ['--force'])
   filter = fr.RepoFilter(args, commit_callback=checker.skip_ignores)
   filter.run()
   


### PR DESCRIPTION
clean-ignore is written to allow leverage of filter-repo to run additional operations on top of clean-ignore. If no arguments are specified nothing is passed to filter-repo and it errors out as it's expecting arguments. I chose "--force" based on previous comments from newren.