### PR TITLE
Dockerise the script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.12
+
+WORKDIR /app
+
+COPY git-filter-repo ./
+
+# The directory that will contain the git directory
+# Must be set up using a volume
+WORKDIR /workdir
+
+ENTRYPOINT [ "python", "/app/git-filter-repo" ]

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -40,6 +40,24 @@ you need to make sure you have a `git_filter_repo.py` file which is
 either a link to or copy of `git-filter-repo`, and you need to place
 that git_filter_repo.py file in $PYTHONPATH.
 
+# Installation via Docker
+
+Download the `git-filter-repo` mentioned above and the `Dockerfile`. Make sure that they are in the same directory.
+
+Build the docker image using the following command:
+
+```shell
+docker build . -t git-filter-repo
+```
+
+To use the script, simply run the following command in any `git` directory in which you want to use the script:
+
+```shell
+docker run -it --rm -v $(pwd):/workdir git-filter-repo --help
+```
+
+Instead of `--help`, you can pass in any arguments you need (as if you were using the script normally).
+
 # Installation via Package Manager
 
 If you want to install via some [package


### PR DESCRIPTION
Adds a docker file that can be used by people who do not have the python tooling installed locally (and do not want to install python just to use a script).

## How to use

1. Clone the repository locally (or just download the `git-filter-repo` and `Dockerfile` files)
2. Build the docker image:

```
docker build . -t git-filter-repo
```

3. Run the docker image:

```
docker run -it --rm -v $(pwd):/workdir git-filter-repo --help
```

For fellow `powershell` users: this has to be changed slightly to:

```
docker run -it --rm -v ${PWD}:/workdir git-filter-repo --help
```

4. Follow the instructions of the script as normal