### PR TITLE
Update gha using dependabot monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
Some of the github actions used within this project are somewhat out dated. For example, the latest version of checkout is currently on v4, but this project is still using v2. This change will make use of dependabot to submit pull requests every month of updates of any of the github actions this project uses if there are newer versions released.

https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot