### PR TITLE
Support git 2.43.0

### DIFF
--- a/git-filter-repo
+++ b/git-filter-repo
@@ -2067,13 +2067,13 @@ EXAMPLES
     if b'--anonymize-map' not in output: # pragma: no cover
       global date_format_permissive
       date_format_permissive = False
-    if b'--mark-tags' not in output: # pragma: no cover
+    if not any(x in output for x in [b'--mark-tags',b'--[no-]mark-tags']): # pragma: no cover
       global write_marks
       write_marks = False
       if args.state_branch:
         # We need a version of git-fast-export with --mark-tags
         raise SystemExit(_("Error: need git >= 2.24.0"))
-    if b'--reencode' not in output: # pragma: no cover
+    if not any(x in output for x in [b'--reencode',  b'--[no-]reencode']): # pragma: no cover
       if args.preserve_commit_encoding:
         # We need a version of git-fast-export with --reencode
         raise SystemExit(_("Error: need git >= 2.23.0"))


### PR DESCRIPTION
This MR resolves https://github.com/newren/git-filter-repo/issues/523

Git 2.43 has --[no-]mark-tags instead of --mark-tags output. Same applies for --reencode. 

Check both options.

Tests: 
```
== t9390-filter-repo.sh ==
ok 1 - check: basic -> basic-filename using '--path filename'
ok 2 - check: basic -> basic-twenty using '--path twenty'
ok 3 - check: basic -> basic-ten using '--path ten'
ok 4 - check: basic -> basic-numbers using '--path ten --path twenty'
ok 5 - check: basic -> basic-filename using '--invert-paths --path-glob t*en*'
ok 6 - check: basic -> basic-numbers using '--invert-paths --path-regex f.*e.*e'
ok 7 - check: basic -> basic-mailmap using '--mailmap ../t9390/sample-mailmap'
ok 8 - check: basic -> basic-replace using '--replace-text ../t9390/sample-replace'
ok 9 - check: basic -> basic-message using '--replace-message ../t9390/sample-message'
ok 10 - check: empty -> empty-keepme using '--path keepme'
ok 11 - check: empty -> more-empty-keepme using '--path keepme --prune-empty=always --prune-degenerate=always'
ok 12 - check: empty -> less-empty-keepme using '--path keepme --prune-empty=never --prune-degenerate=never'
ok 13 - check: degenerate -> degenerate-keepme using '--path moduleA/keepme'
ok 14 - check: degenerate -> degenerate-moduleA using '--path moduleA'
ok 15 - check: degenerate -> degenerate-globme using '--path-glob *me'
ok 16 - check: degenerate -> degenerate-keepme-noff using '--path moduleA/keepme --no-ff'
ok 17 - check: unusual -> unusual-filtered using '--path '
ok 18 - check: unusual -> unusual-mailmap using '--mailmap ../t9390/sample-mailmap'
ok 19 - --path-rename sequences/tiny:sequences/small
ok 20 - --path-rename sequences:numbers
ok 21 - --path-rename-prefix values:numbers
ok 22 - --path-rename squashing
ok 23 - --path-rename inability to squash
ok 24 - --paths-from-file
ok 25 - Mixing filtering and renaming paths, not enough filters
ok 26 - Mixing filtering and renaming paths, enough filters
ok 27 - Mixing filtering and to-subdirectory-filter
ok 28 - --tag-rename
ok 29 - tag of tag before relevant portion of history
ok 30 - --subdirectory-filter
ok 31 - --subdirectory-filter with trailing slash
ok 32 - --to-subdirectory-filter
ok 33 - --use-base-name
ok 34 - refs/replace/ to skip a parent
ok 35 - refs/replace/ to add more initial history
ok 36 - creation/deletion/updating of replace refs
ok 37 - --debug
ok 38 - --dry-run
ok 39 - --dry-run --debug
ok 40 - --dry-run --stdin
ok 41 - --analyze
ok 42 - --analyze --report-dir
ok 43 - --replace-text all options
ok 44 - --replace-text binary zero_byte-0_char
ok 45 - --replace-text binary zero_byte-no_0_char
ok 46 - --replace-text text-file no_zero_byte-zero_char
ok 47 - --strip-blobs-bigger-than
ok 48 - --strip-blobs-with-ids
ok 49 - commit message rewrite
ok 50 - commit hash unchanged if requested
ok 51 - commit message encoding preserved if requested
ok 52 - commit message rewrite unsuccessful
ok 53 - startup sanity checks
ok 54 - other startup error cases and requests for help
ok 55 - invalid fast-import directives
ok 56 - mailmap sanity checks
ok 57 - incremental import
ok 58 - --target
ok 59 - --refs
ok 60 - --refs and --replace-text
ok 61 - reset to specific refs
ok 62 - handle funny characters
ok 63 - --state-branch with changing renames
ok 64 - --state-branch with expanding paths and refs
ok 65 - degenerate merge with non-matching filenames
ok 66 - degenerate merge with typechange
ok 67 - Filtering a blob to make it match previous version
ok 68 - tweaking just a tag
ok 69 - --version
ok 70 - empty author ident
# passed all 70 test(s)
1..70


== t9391-filter-repo-lib-usage.sh ==
ok 1 - commit_info.py
ok 2 - file_filter.py
ok 3 - print_progress.py
ok 4 - rename-master-to-develop.py
ok 5 - strip-cvs-keywords.py
ok 6 - setup two extra repositories
ok 7 - splice_repos.py
ok 8 - create_fast_export_output.py
ok 9 - unusual.py
ok 10 - erroneous.py
ok 11 - other error cases
ok 12 - lint-history
# passed all 12 test(s)
1..12


== t9392-python-callback.sh ==
ok 1 - --filename-callback
ok 2 - --message-callback
ok 3 - --name-callback
ok 4 - --email-callback
ok 5 - --refname-callback
ok 6 - --refname-callback sanity check
ok 7 - --blob-callback
ok 8 - --commit-callback
ok 9 - --tag-callback
ok 10 - --reset-callback
ok 11 - callback has return statement sanity check
ok 12 - Callback read from a file
# passed all 12 test(s)
1..12
```