### PR TITLE
args: allow to use multiple `--refs` arguments

### DIFF
--- a/git-filter-repo
+++ b/git-filter-repo
@@ -1990,7 +1990,7 @@ EXAMPLES
     #     commit has an excluded ancestor as a parent we have no way of
     #     knowing what it is an ancestor of without doing a special
     #     full-graph walk.
-    misc.add_argument('--refs', nargs='+',
+    misc.add_argument('--refs', action='append',
         help=_("Limit history rewriting to the specified refs.  Implies "
                "--partial.  In addition to the normal caveats of --partial "
                "(mixing old and new history, no automatic remapping of "


### PR DESCRIPTION
Refs arguments are passed to `git rev-list` allowing user to configure the set of commits to operate on. IMHO it's important to be able to pass through any desirable rev-list configurations. This often requires using multiple `--refs` arguments.

Examples:
* `git filter-repo --refs head1 --refs head2`
* `git filter-repo --refs='--glob:refs/heads/*' --refs='--glob:refs/tags/*'`
* `git filter-repo --refs='--glob:refs/heads/*' --refs='--not' --refs='master`
