### PR TITLE
Cleanup callback scope

### DIFF
--- a/git-filter-repo
+++ b/git-filter-repo
@@ -51,6 +51,13 @@ __all__ = ["Blob", "Reset", "FileChange", "Commit", "Tag", "Progress",
            "string_to_date", "date_to_string",
            "record_id_rename", "GitUtils", "FilteringOptions", "RepoFilter"]
 
+# The globals to make visible to callbacks. They will see all our imports for
+# free, as well as our public API.
+public_globals = ["__builtins__", "argparse", "collections", "fnmatch",
+                  "gettext", "io", "os", "platform", "re", "shutil",
+                  "subprocess", "sys", "time", "textwrap", "tzinfo",
+                  "timedelta", "datetime"] + __all__
+
 deleted_hash = b'0'*40
 write_marks = True
 date_format_permissive = True
@@ -2837,9 +2844,11 @@ class RepoFilter(object):
 
   def _handle_arg_callbacks(self):
     def make_callback(argname, str):
+      callback_globals = {g: globals()[g] for g in public_globals}
+      callback_locals = {}
       exec('def callback({}, _do_not_use_this_var = None):\n'.format(argname)+
-           '  '+'\n  '.join(str.splitlines()), globals())
-      return callback #namespace['callback']
+           '  '+'\n  '.join(str.splitlines()), callback_globals, callback_locals)
+      return callback_locals['callback']
     def handle(type):
       callback_field = '_{}_callback'.format(type)
       code_string = getattr(self._args, type+'_callback')


### PR DESCRIPTION
Callbacks currently inherit the global scope from the library, which leaks private API details. This change limits the globals visible to callbacks to just the public library API and its imports (so using, e.g., `re` continues to work without import).

This is technically a breaking change, if anyone relies on these extra globals, but this change seems well within the API guarantees.

The only question is how much should be made visible? Several of these imports have questionable utility for callbacks, so might make sense to prune from the list. What about Python `__`-globals? Some of those might be necessary, and they could be forwarded or stubbed.

I've included a diff of the globals and locals for your review:

```diff
 Callback globals:

 {
-  'Alias': <class '__main__.Alias'>,
-  'AncestryGraph': <class '__main__.AncestryGraph'>,
   'Blob': <class '__main__.Blob'>,
   'Checkpoint': <class '__main__.Checkpoint'>,
   'Commit': <class '__main__.Commit'>,
-  'DualFileWriter': <class '__main__.DualFileWriter'>,
   'FastExportParser': <class '__main__.FastExportParser'>,
   'FileChange': <class '__main__.FileChange'>,
   'FilteringOptions': <class '__main__.FilteringOptions'>,
-  'FixedTimeZone': <class '__main__.FixedTimeZone'>,
   'GitUtils': <class '__main__.GitUtils'>,
-  'HASH_TO_ID': {},
-  'ID_TO_HASH': {},
-  'InputFileBackup': <class '__main__.InputFileBackup'>,
-  'LiteralCommand': <class '__main__.LiteralCommand'>,
-  'MailmapInfo': <class '__main__.MailmapInfo'>,
-  'PathQuoting': <class '__main__.PathQuoting'>,
   'Progress': <class '__main__.Progress'>,
   'ProgressWriter': <class '__main__.ProgressWriter'>,
-  'RepoAnalyze': <class '__main__.RepoAnalyze'>,
   'RepoFilter': <class '__main__.RepoFilter'>,
   'Reset': <class '__main__.Reset'>,
-  'SubprocessWrapper': <class '__main__.SubprocessWrapper'>,
   'Tag': <class '__main__.Tag'>,
-  '_': <function gettext_poison>,
-  '_GitElement': <class '__main__._GitElement'>,
-  '_GitElementWithId': <class '__main__._GitElementWithId'>,
-  '_IDS': <__main__._IDs object>,
-  '_IDs': <class '__main__._IDs'>,
-  '_SKIPPED_COMMITS': set(),
-  '__all__': [ 'Blob',
-               'Reset',
-               'FileChange',
-               'Commit',
-               'Tag',
-               'Progress',
-               'Checkpoint',
-               'FastExportParser',
-               'ProgressWriter',
-               'string_to_date',
-               'date_to_string',
-               'record_id_rename',
-               'GitUtils',
-               'FilteringOptions',
-               'RepoFilter'],
-  '__annotations__': {},
   '__builtins__': <module 'builtins' (built-in)>,
-  '__cached__': None,
-  '__doc__': '\n'
-             'git-filter-repo filters git repositories, similar to git filter-branch, BFG\n'
-             'repo cleaner, and others.  The basic idea is that it works by running\n'
-             '   git fast-export <options> | filter | git fast-import <options>\n'
-             'where this program not only launches the whole pipeline but also serves as\n'
-             "the 'filter' in the middle.  It does a few additional things on top as well\n"
-             'in order to make it into a well-rounded filtering tool.\n'
-             '\n'
-             'git-filter-repo can also be used as a library for more involved filtering\n'
-             'operations; however:\n'
-             '  ***** API BACKWARD COMPATIBILITY CAVEAT *****\n'
-             '  Programs using git-filter-repo as a library can reach pretty far into its\n'
-             '  internals, but I am not prepared to guarantee backward compatibility of\n'
-             '  all APIs.  I suspect changes will be rare, but I reserve the right to\n'
-             '  change any API.  Since it is assumed that repository filtering is\n'
-             "  something one would do very rarely, and in particular that it's a\n"
-             '  one-shot operation, this should not be a problem in practice for anyone.\n'
-             '  However, if you want to re-use a program you have written that uses\n'
-             '  git-filter-repo as a library (or makes use of one of its --*-callback\n'
-             '  arguments), you should either make sure you are using the same version of\n'
-             '  git and git-filter-repo, or make sure to re-test it.\n'
-             '\n'
-             '  If there are particular pieces of the API you are concerned about, and\n'
-             '  there is not already a testcase for it in t9391-lib-usage.sh or\n'
-             '  t9392-python-callback.sh, please contribute a testcase.  That will not\n'
-             '  prevent me from changing the API, but it will allow you to look at the\n'
-             '  history of a testcase to see whether and how the API changed.\n'
-             '  ***** END API BACKWARD COMPATIBILITY CAVEAT *****\n',
-  '__file__': '/path/to/git-filter-repo',
-  '__loader__': <_frozen_importlib_external.SourceFileLoader object>,
-  '__name__': '__main__',
-  '__package__': None,
-  '__spec__': None,
-  '__warningregistry__': {'version': 6},
-  '_timedelta_to_seconds': <function _timedelta_to_seconds>,
   'argparse': <module 'argparse' from 'argparse.py'>,
-  'callback': <function callback>,
   'collections': <module 'collections' from '__init__.py'>,
-  'date_format_permissive': True,
   'date_to_string': <function date_to_string>,
   'datetime': <class 'datetime.datetime'>,
-  'decode': <function decode>,
-  'deleted_hash': b'0000000000000000000000000000000000000000',
   'fnmatch': <module 'fnmatch' from 'fnmatch.py'>,
   'gettext': <module 'gettext' from 'gettext.py'>,
-  'gettext_poison': <function gettext_poison>,
-  'glob_to_regex': <function glob_to_regex>,
   'io': <module 'io' (frozen)>,
-  'main': <function main>,
   'os': <module 'os' (frozen)>,
   'platform': <module 'platform' from 'platform.py'>,
   're': <module 're' from '__init__.py'>,
   'record_id_rename': <function record_id_rename>,
-  'setup_gettext': <function setup_gettext>,
   'shutil': <module 'shutil' from 'shutil.py'>,
   'string_to_date': <function string_to_date>,
-  'subproc': <module 'subprocess' from 'subprocess.py'>,
   'subprocess': <module 'subprocess' from 'subprocess.py'>,
   'sys': <module 'sys' (built-in)>,
   'textwrap': <module 'textwrap' from 'textwrap.py'>,
   'time': <module 'time' (built-in)>,
   'timedelta': <class 'datetime.timedelta'>,
   'tzinfo': <class 'datetime.tzinfo'>,
-  'write_marks': False,
 }
 
 Callback locals:

 { '_do_not_use_this_var': { 'ancestry_graph': <__main__.AncestryGraph object>,
                             'commit_rename_func': <bound method RepoFilter._translate_commit_hash of <__main__.RepoFilter object>>,
                             'had_file_changes': False,
                             'orig_parents': [],
                             'original_ancestry_graph': <__main__.AncestryGraph object>},
   'commit': <__main__.Commit object>}
```

Dumped with:

```sh
git init tmp && cd tmp && git commit -m '' --allow-empty --allow-empty-message
git-filter-repo --quiet --commit-callback '
  g, l = globals(), locals()
  import pprint
  print("Callback globals:", file=sys.stderr)
  pprint.pprint(g, indent=2, width=120, stream=sys.stderr)
  print("\nCallback locals:", file=sys.stderr)
  pprint.pprint(l, indent=2, width=120, stream=sys.stderr)
' 2>&1 >/dev/null |
sed -E -e 's, at 0x[0-9a-f]{9},,g' \
       -e "s, from '.*/, from ',g"
```