### PR TITLE
fix(clean-ignore): Consider .gitignore exclusions

### DIFF
--- a/contrib/filter-repo-demos/clean-ignore
+++ b/contrib/filter-repo-demos/clean-ignore
@@ -55,8 +55,12 @@ class CheckIgnores:
         if rest == b'::':
           self.okay.add(name)
         else:
-          self.ignored.add(name)
-          ignored.add(name)
+          rule = rest.split(b":")[-1]
+          if rule.decode()[0] == "!":
+            self.okay.add(name)
+          else:
+            self.ignored.add(name)
+            self.add(name)
 
     return ignored
 


### PR DESCRIPTION
I ran across what I think is the same issue as reported in #76.  My repository's `.gitignore` has, among other things,
```.gitignore
*.mat
!path/to/particular.mat
```
Running `clean-ignore --path-glob "*"` results in all `*.mat` files being stripped from the repository history.  I'm using
```
git version 2.39.3 (Apple Git-146)
```
and if I run
```bash
git check-ignore --verbose --non-matching --no-index path/to/particular.mat
```
I see
```
.gitignore:2:!path/to/particular.mat    path/to/particular.mat
```
It sounds like the expected behavior from `git check-ignore` is to see no output, but that doesn't appear to be the case here.  In order to get the `clean-ignore` script to correctly handle the exclusions in the `.gitignore` file, I needed to make this slight tweak to it.

If it's the case that the real problem lies in `git` itself, and not in this repository, then I could file an issue against it instead.