### PR TITLE
filter-repo: skip over unexpected git-catfile output

### DIFF
--- a/git-filter-repo
+++ b/git-filter-repo
@@ -1577,12 +1577,15 @@ class GitUtils(object):
     unpacked_size = {}
     packed_size = {}
     for line in cf.stdout:
-      sha, objtype, objsize, objdisksize = line.split()
-      objsize, objdisksize = int(objsize), int(objdisksize)
-      if objtype == b'blob':
-        unpacked_size[sha] = objsize
-        packed_size[sha] = objdisksize
-        num_blobs += 1
+      try:
+        sha, objtype, objsize, objdisksize = line.split()
+        objsize, objdisksize = int(objsize), int(objdisksize)
+        if objtype == b'blob':
+          unpacked_size[sha] = objsize
+          packed_size[sha] = objdisksize
+          num_blobs += 1
+      except ValueError:
+        sys.stderr.write(_("Error: unexpected `git cat-file` output: \"%s\"\n") % line)
       if not quiet:
         blob_size_progress.show(processed_blobs_msg % num_blobs)
     cf.wait()


### PR DESCRIPTION
We have encountered, possibility corrupted, Git repositories that return unexpected `git cat-file` output lines:

```
 File "/git-filter-repo", line 4149, in <module>
    main()
  File "/git-filter-repo", line 4143, in main
    RepoAnalyze.run(args)
  File "/git-filter-repo", line 2723, in run
    stats = RepoAnalyze.gather_data(args)
  File "/git-filter-repo", line 2366, in gather_data
    unpacked_size, packed_size = GitUtils.get_blob_sizes()
  File "/git-filter-repo", line 1580, in get_blob_sizes
    sha, objtype, objsize, objdisksize = line.split()
ValueError: not enough values to unpack (expected 4, got 2)
```

 Let's skip over those lines and print them to stderr for further analysis.

---

The script currently doesn't use lots of Python exception handling and I think we don't write to `stderr` at all yet. Please let me know if there is a better/more fitting way to make this change. I was contemplating if we should let the script die if  we encounter such weird content but decided against it for now (mainly to see if there is one or many bad output lines).