### PR TITLE
filter-repo: Accept multiline git config values

### DIFF
--- a/git-filter-repo
+++ b/git-filter-repo
@@ -1689,8 +1689,9 @@ class GitUtils(object):
       raise SystemExit('fatal: {}'.format(e))
 
     # FIXME: Ignores multi-valued keys, just let them overwrite for now
-    return dict(line.split(b'=', maxsplit=1)
-                for line in output.strip().split(b"\n"))
+    keyvalues = re.split(b'^([a-zA-Z0-9.-]+)=', output, flags=re.MULTILINE)
+    return {keyvalues[i].strip(): keyvalues[i + 1].strip()
+            for i in range(1, len(keyvalues), 2)}
 
   @staticmethod
   def get_blob_sizes(quiet = False):


### PR DESCRIPTION
Some git config options can contain multiline values, for example aliases. With the current simple split on = this fails with a stacktrace so that git-filter-repo is unusable.

This patch uses a multiline regular expression to split the git config --list string at any beginning line followed by an alphanumeric name with '-' and '.' followed by '='. In some cases this can falsely identify multiline values as a new variable name that does not exist. But it should work for most usual multiline config options correctly.

Corresponding bugreport #603 