### PR TITLE
Give a more succinct error message when user specifies nonexistent files

### DIFF
--- a/git-filter-repo
+++ b/git-filter-repo
@@ -4965,7 +4965,12 @@ class RepoFilter(object):
 
 def main():
   setup_gettext()
-  args = FilteringOptions.parse_args(sys.argv[1:])
+  try:
+    args = FilteringOptions.parse_args(sys.argv[1:])
+  except FileNotFoundError as e:
+    filename = e.filename.decode('utf-8') if type(e.filename) == bytes else e.filename
+    raise SystemExit(_("Error! Specified file '%s' does not exist") % filename)
+
   if args.analyze:
     RepoAnalyze.run(args)
   else:


### PR DESCRIPTION
Currently specifying nonexistent files to options gives a whole Python backtrace, with the filename output in `b'filename'` bytestring notation which is even more confusing.

There are plenty of approaches here, this just catches any FileNotFoundErrors and raises a more succinct error message about it, which doesn't tell you which is the offending argument, but that should be apparent enough, and in any case, this seems to me like strictly an improvement over the backtrace that currently happens.