### PR TITLE
Add missing newline in printout

### DIFF
--- a/git-filter-repo
+++ b/git-filter-repo
@@ -2903,7 +2903,7 @@ class RepoAnalyze(object):
 
     if os.path.isdir(reportdir):
       if args.force:
-        sys.stdout.write(_("Warning: Removing recursively: \"%s\"") % decode(reportdir))
+        sys.stdout.write(_("Warning: Removing recursively: \"%s\"\n") % decode(reportdir))
         shutil.rmtree(reportdir)
       else:
         sys.stdout.write(_("Error: dir already exists (use --force to delete): \"%s\"\n") % decode(reportdir))


### PR DESCRIPTION
Fixes the issue reported in #640.

This print-out message is missing a terminating line-break,
and gets partially overwritten by other text:

Warning: Removing recursively: <filename>

Example output:

Processed 28217 blob sizesely: ".git\filter-repo\analysis"

(Notice how the words "sizes" and "recursively" get combined,
into "sizesely" on the first line.)

Adding the missing newline corrects the output:

Warning: Removing recursively: ".git\filter-repo\analysis"
Processed 28217 blob sizes