### PR TITLE
Postpone refs matching to after setting working dir to repo dir.

### DIFF
--- a/contrib/filter-repo-demos/bfg-ish
+++ b/contrib/filter-repo-demos/bfg-ish
@@ -382,10 +382,11 @@ class BFG_ish:
 
   def run(self):
     bfg_args = self.parse_options()
-    preserve_refs = self.get_preservation_info(bfg_args.preserve_ref_tips)
 
     work_dir = os.getcwd()
     os.chdir(bfg_args.repo)
+
+    preserve_refs = self.get_preservation_info(bfg_args.preserve_ref_tips)
     bfg_args.delete_files = java_to_fnmatch_glob(bfg_args.delete_files)
     bfg_args.delete_folders = java_to_fnmatch_glob(bfg_args.delete_folders)
     bfg_args.filter_content_including = \


### PR DESCRIPTION
subproc.Popen() calls in bfg-ish relies on a os.chdir() call to have been made beforehand for each child process to run in the repo dir as required.

get_preservation_info has a subproc.Popen() call that before this change is executed before the required os.chdir() call.