### PR TITLE
Update examples-from-user-filed-issues.md: = vs. == bug.

### DIFF
--- a/Documentation/examples-from-user-filed-issues.md
+++ b/Documentation/examples-from-user-filed-issues.md
@@ -233,7 +233,7 @@ where the author email is currently `example@test.com`:
 
 ```
 git filter-repo --refs main~5..main --commit-callback '
-    if commit.author_email = b"example@test.com":
+    if commit.author_email == b"example@test.com":
         commit.author_name = "Raphaël González".encode()
         commit.author_email = b"rgonzalez@test.com"
 '


### PR DESCRIPTION
Classic `=` used in conditional where comparison `==` was intended.

I tried the example and ran into:
```
SyntaxError: cannot assign to attribute here. Maybe you meant '==' instead of '='?
```

This fixes that.