### PR TITLE
Add rough cut of 'blobbase'

### DIFF
--- a/git-filter-repo
+++ b/git-filter-repo
@@ -2029,6 +2029,12 @@ EXAMPLES
     contents.add_argument('--strip-blobs-with-ids', metavar='BLOB-ID-FILENAME',
         help=_("Read git object ids from each line of the given file, and "
                "strip all of them from history"))
+    contents.add_argument('--blobbase', metavar='BLOB-SHAS-AND-PATHS',
+        help=_("Process an annotated blob-shas-and-paths.txt file. 'blobbase' "
+               "because it uses a command system similar to git's interactive "
+               "rebase. Commands: k, keep <sha> = keep blob; s, strip <sha> = "
+               "strip blob. Keep is the default if no command has been "
+               "specified."))
 
     refrename = parser.add_argument_group(title=_("Renaming of refs "
                                               "(see also --refname-callback)"))
@@ -2444,6 +2450,16 @@ EXAMPLES
         args.strip_blobs_with_ids = set(f.read().split())
     else:
       args.strip_blobs_with_ids = set()
+    # blobbase leverages args.strip_blobs_with_ids
+    if args.blobbase:
+      # Commands: k, keep = keep blob; s, strip = strip blob. No command means keep.
+      with open(args.blobbase, 'br') as f:
+        # Header lines start with "===" or "Format:"
+        # Blank lines are blank, comments start with "#"
+        # Not annotating a blob is interpreted as "keep", keep is keep
+        # All this has to do is find the strip lines which are distinct from the above lines
+        # git.git:sequencer.c:parse_insn_line() does not require the command to be in the first column
+        args.strip_blobs_with_ids.update(parts[1] for parts in (line.split() for line in f) if len(parts) >= 2 and parts[0].decode()[0:1] == 's')
     if (args.partial or args.refs) and not args.replace_refs:
       args.replace_refs = 'update-no-add'
     args.repack = not (args.partial or args.refs or args.no_gc)
@@ -2874,6 +2890,7 @@ class RepoAnalyze(object):
     # List of filenames and sizes in descending order
     with open(os.path.join(reportdir, b"blob-shas-and-paths.txt"), 'bw') as f:
       f.write(("=== %s ===\n" % _("Files by sha and associated pathnames in reverse size")).encode())
+      f.write(("=== %s ===\n" % _("To use blobbase, prefix lines with commands: k, keep = keep blob; s, strip = strip blob. No command means keep.")).encode())
       f.write(_("Format: sha, unpacked size, packed size, filename(s) object stored as\n").encode())
       for sha, size in sorted(stats['packed_size'].items(),
                               key=lambda x:(x[1],x[0]), reverse=True):

--- a/git-filter-repo
+++ b/git-filter-repo
@@ -2032,7 +2032,7 @@ EXAMPLES
     contents.add_argument('--blobbase', metavar='BLOB-SHAS-AND-PATHS',
         help=_("Process an annotated blob-shas-and-paths.txt file. 'blobbase' "
                "because it uses a command system similar to git's interactive "
-               "rebase. Commands: k, keep <sha> = keep blob; s, strip <sha> = "
+               "rebase. Commands: k, keep sha = keep blob; s, strip sha = "
                "strip blob. Keep is the default if no command has been "
                "specified."))
 
@@ -2454,9 +2454,11 @@ EXAMPLES
     if args.blobbase:
       # Commands: k, keep = keep blob; s, strip = strip blob. No command means keep.
       with open(args.blobbase, 'br') as f:
-        # Header lines start with "===" or "Format:"
-        # Blank lines are blank, comments start with "#"
-        # Not annotating a blob is interpreted as "keep", keep is keep
+        # Header lines start with '===' or 'Format:'
+        # Blank lines are blank, comments start with '#'
+        # Not annotating a blob is interpreted as 'keep', keep is keep
+        # Pathbase match lines start with 'm'. This means one blob_shas_and_paths can be annotated for use with both
+        # blobbase and pathbase.
         # All this has to do is find the strip lines which are distinct from the above lines
         # git.git:sequencer.c:parse_insn_line() does not require the command to be in the first column
         args.strip_blobs_with_ids.update(parts[1] for parts in (line.split() for line in f) if len(parts) >= 2 and parts[0].decode()[0:1] == 's')


### PR DESCRIPTION
This is a rough draft for a "blobbase" feature. It operates like git's interactive rebase but is not interactive. I'm not intending for this to be merged; just looking for comments on whether this _could be_ merged. It would need test cases at least.

After running `git-filter-repo --analyze`, one annotates the resulting `.git/filter-repo/analysis/blob-shas-and-paths.txt` with commands and feeds that back in via `git-filter-repo --blobbase`. This avoids most of the human error inherent in a person transforming a `blob-shas-and-paths.txt` into a file that `--strip-blobs-with-ids` can handle.

The new process leaves the paths in place making blob selection easier.
It is a process that most git users will already be familiar with from rebase.

Unless the extra line in the `blob-shas-and-paths.txt` file causes issues, this is 100% backwards compatible.

I am currently using this to clean a repo that had a lot of build artifacts checked in. I find it better than (re-)creating a blob-sha-only file from `blob-shas-and-paths.txt` because I can see what I'm selecting and it's less transformation than making the blobs-only file.
Part of my equation is this lets me do the annotation slowly over time/many iterations while I figure out what needs to come out and what stays.

Original commit message:
Like interactive rebase for blobs