### PR TITLE
filter-repo: don't crash on streams containing gpgsig blocks

### DIFF
--- a/git-filter-repo
+++ b/git-filter-repo
@@ -1311,6 +1311,10 @@ class FastExportParser(object):
       (author_name, author_email, author_date) = \
         (committer_name, committer_email, committer_date)
 
+    while self._currentline.startswith(b'gpgsig '):
+      self._advance_currentline()
+      self._parse_data()
+
     encoding = None
     if self._currentline.startswith(b'encoding '):
       encoding = self._parse_encoding()

--- a/t/t9390-filter-repo-basics.sh
+++ b/t/t9390-filter-repo-basics.sh
@@ -380,6 +380,54 @@ test_expect_success 'commit hash unchanged if requested' '
 	)
 '
 
+test_expect_success 'commit signatures ignored' '
+	(
+		git init commit_signatures &&
+		cd commit_signatures &&
+
+		cat >input <<-\EOF &&
+		feature done
+		commit refs/heads/develop
+		mark :1
+		author Just Me <just@here.org> 1234567890 -0200
+		committer Just Me <just@here.org> 1234567890 -0200
+		data 2
+		A
+
+		commit refs/heads/develop
+		mark :2
+		author Just Me <just@here.org> 1234567890 -0200
+		committer Just Me <just@here.org> 1234567890 -0200
+		gpgsig sha1 openpgp
+		data 21
+		sha1 signature stuff
+		data 2
+		B
+
+		commit refs/heads/develop
+		mark :3
+		author Just Me <just@here.org> 1234567890 -0200
+		committer Just Me <just@here.org> 1234567890 -0200
+		gpgsig sha1 openpgp
+		data 21
+		sha1 signature stuff
+		gpgsig sha256 openpgp
+		data 23
+		sha256 signature stuff
+		data 2
+		C
+		done
+		EOF
+
+		git fast-import --quiet <input &&
+
+		git filter-repo --force &&
+		test $(git rev-list --count develop) = 3 &&
+		printf "%s\n" develop develop~ develop~2 | git cat-file --batch >commits &&
+		! grep "^gpgsig" commits
+	)
+'
+
 test_expect_success 'commit message encoding preserved if requested' '
 	(
 		git init commit_message_encoding &&


### PR DESCRIPTION
This is to address #139. It's the first PR of the 3-PR plan described in:

https://github.com/newren/git-filter-repo/issues/139#issuecomment-4342791288

Let me know if you prefer me to send this as a patch series (or maybe a single patch) to the Git mailing list.

In the future we want to preserve commit signatures.

To prepare for that, let's teach the fast-export stream parser to recognize and skip `gpgsig` header blocks followed by a `data` block for the signature content. Git >= v2.50.0 can emit such blocks between `committer` and `encoding`/`data`, using for example:

  `git fast-export --signed-commits=verbatim`

Up to two `gpgsig` blocks may appear (one per hash algorithm).

Note that no new flags are passed to `git fast-export`, so signatures are still stripped in practice. We only prevent an assertion failure in `_parse_data` if a stream containing `gpgsig` blocks is fed in (e.g. by hand or by a future version of filter-repo).