### PR TITLE
filter-repo: store and roundtrip commit signatures

### DIFF
--- a/git-filter-repo
+++ b/git-filter-repo
@@ -745,6 +745,7 @@ class Commit(_GitElementWithId):
                parents,
                original_id = None,
                encoding = None, # encoding for message; None implies UTF-8
+               signatures = None,
                **kwargs):
     _GitElementWithId.__init__(self)
     self.old_id = self.id
@@ -775,6 +776,9 @@ class Commit(_GitElementWithId):
 
     # Record date the commit was made
     self.committer_date  = committer_date
+
+    # Record commit signatures
+    self.signatures  = signatures
 
     # Record commit message and its encoding
     self.encoding = encoding
@@ -809,6 +813,8 @@ class Commit(_GitElementWithId):
                   self.author_name, self.author_email, self.author_date,
                   self.committer_name, self.committer_email, self.committer_date
                ))
+    for algo, fmt, sig in self.signatures or []:
+      file_.write(b'gpgsig %s %s\ndata %d\n%s' % (algo, fmt, len(sig), sig))
     if self.encoding:
       file_.write(b'encoding %s\n' % self.encoding)
     file_.write(b'data %d\n%s%s' %
@@ -1055,6 +1061,7 @@ class FastExportParser(object):
     self._user_regexes = {}
     for user in (b'author', b'committer', b'tagger'):
       self._user_regexes[user] = re.compile(user + b' (.*?) <(.*?)> (.*)\n$')
+    self._gpgsig_re = re.compile(br'gpgsig (\S+) (\S+)\n$')
 
   def _advance_currentline(self):
     """
@@ -1158,6 +1165,12 @@ class FastExportParser(object):
     encoding = self._currentline[len(b'encoding '):].rstrip()
     self._advance_currentline()
     return encoding
+
+  def _parse_signature(self):
+    algo, fmt = self._gpgsig_re.match(self._currentline).groups()
+    self._advance_currentline()
+    sig = self._parse_data()
+    return (algo, fmt, sig)
 
   def _parse_ref_line(self, refname):
     """
@@ -1311,9 +1324,9 @@ class FastExportParser(object):
       (author_name, author_email, author_date) = \
         (committer_name, committer_email, committer_date)
 
+    signatures = []
     while self._currentline.startswith(b'gpgsig '):
-      self._advance_currentline()
-      self._parse_data()
+      signatures.append(self._parse_signature())
 
     encoding = None
     if self._currentline.startswith(b'encoding '):
@@ -1360,7 +1373,8 @@ class FastExportParser(object):
     commit = Commit(branch,
                     author_name,    author_email,    author_date,
                     committer_name, committer_email, committer_date,
-                    commit_msg, file_changes, parents, original_id, encoding)
+                    commit_msg, file_changes, parents, original_id,
+                    encoding, signatures)
 
     # If fast-export text had a mark for this commit, need to make sure this
     # mark translates to the commit's true id.

--- a/t/t9390-filter-repo-basics.sh
+++ b/t/t9390-filter-repo-basics.sh
@@ -430,6 +430,23 @@ test_expect_success 'commit signatures ignored' '
 	)
 '
 
+test_expect_success 'commit signatures roundtrip via --stdin' '
+	(
+		git init commit_signatures_roundtrip &&
+		cd commit_signatures_roundtrip &&
+
+		git filter-repo --stdin --dry-run --force <../sig_input &&
+
+		test_path_is_file .git/filter-repo/fast-export.filtered &&
+		grep "^gpgsig sha1 openpgp$" .git/filter-repo/fast-export.filtered >out &&
+		test_line_count = 2 out &&
+		grep "^gpgsig sha256 openpgp$" .git/filter-repo/fast-export.filtered >out &&
+		test_line_count = 1 out &&
+		grep "sha1 signature stuff" .git/filter-repo/fast-export.filtered &&
+		grep "sha256 signature stuff" .git/filter-repo/fast-export.filtered
+	)
+'
+
 test_expect_success 'commit message encoding preserved if requested' '
 	(
 		git init commit_message_encoding &&

--- a/t/t9390-filter-repo-basics.sh
+++ b/t/t9390-filter-repo-basics.sh
@@ -380,46 +380,48 @@ test_expect_success 'commit hash unchanged if requested' '
 	)
 '
 
+test_expect_success 'prepare signature tests' '
+	cat >sig_input <<-\EOF
+	feature done
+	commit refs/heads/develop
+	mark :1
+	author Just Me <just@here.org> 1234567890 -0200
+	committer Just Me <just@here.org> 1234567890 -0200
+	data 2
+	A
+
+	commit refs/heads/develop
+	mark :2
+	author Just Me <just@here.org> 1234567890 -0200
+	committer Just Me <just@here.org> 1234567890 -0200
+	gpgsig sha1 openpgp
+	data 21
+	sha1 signature stuff
+	data 2
+	B
+
+	commit refs/heads/develop
+	mark :3
+	author Just Me <just@here.org> 1234567890 -0200
+	committer Just Me <just@here.org> 1234567890 -0200
+	gpgsig sha1 openpgp
+	data 21
+	sha1 signature stuff
+	gpgsig sha256 openpgp
+	data 23
+	sha256 signature stuff
+	data 2
+	C
+	done
+	EOF
+'
+
 test_expect_success 'commit signatures ignored' '
 	(
 		git init commit_signatures &&
 		cd commit_signatures &&
 
-		cat >input <<-\EOF &&
-		feature done
-		commit refs/heads/develop
-		mark :1
-		author Just Me <just@here.org> 1234567890 -0200
-		committer Just Me <just@here.org> 1234567890 -0200
-		data 2
-		A
-
-		commit refs/heads/develop
-		mark :2
-		author Just Me <just@here.org> 1234567890 -0200
-		committer Just Me <just@here.org> 1234567890 -0200
-		gpgsig sha1 openpgp
-		data 21
-		sha1 signature stuff
-		data 2
-		B
-
-		commit refs/heads/develop
-		mark :3
-		author Just Me <just@here.org> 1234567890 -0200
-		committer Just Me <just@here.org> 1234567890 -0200
-		gpgsig sha1 openpgp
-		data 21
-		sha1 signature stuff
-		gpgsig sha256 openpgp
-		data 23
-		sha256 signature stuff
-		data 2
-		C
-		done
-		EOF
-
-		git fast-import --quiet <input &&
+		git fast-import --quiet <../sig_input &&
 
 		git filter-repo --force &&
 		test $(git rev-list --count develop) = 3 &&


### PR DESCRIPTION
This is to address https://github.com/newren/git-filter-repo/issues/139. It's the second PR of the 3-PR plan described in:

https://github.com/newren/git-filter-repo/issues/139#issuecomment-4342791288

Commit 2a118d2ac2184da7ab60d45a5ba1f3dfdedb4c59 (filter-repo: don't crash on streams containing gpgsig blocks, 2026-04-29) taught the parser to skip `gpgsig` blocks. This avoids crashes when commit signatures are present, but this also discards them which prevents us from writing them back unchanged.

To allow us to write back commit signatures unchanged, let's instead parse them and store the parsed elements on the `Commit` object as a list of `(algo, format, signature)` tuples in a new `signatures` attribute.
    
Let's then emit them again in `Commit.dump()` using the fast-import grammar:
    
```
        gpgsig <algo> <format>
        data <n>
        <signature>
```

A commit may carry up to two signatures (one per hash algorithm), and the new `signatures` attribute defaults to `None` so existing callers and commit callbacks remain unaffected.

No new flags are passed to `git fast-export` yet, so by default signatures are still stripped before filter-repo sees them. It's left to future work to add a user-facing option to request `--signed-commits=verbatim`. Note that a signature is only valid for the exact commit content it was made over, so a preserved signature is only meaningful when the commit is reproduced unchanged. Deciding when to drop signatures for rewritten commits is left to that future work.

To verify that roundtripping works, let's also add a test that feeds the stream via `--stdin --dry-run` and confirms the signatures survive in the filtered output.