### PR TITLE
Fix a number of typos in code comments and docs

### DIFF
--- a/Documentation/FAQ.md
+++ b/Documentation/FAQ.md
@@ -158,7 +158,7 @@ and you didn't read even the beginning of the manual
 git-filter-repo destructively rewrites history
 ```
 and you think it's okay to run a command with `--force` in it on
-something you don't have a backup of, then now is the time to reasses
+something you don't have a backup of, then now is the time to reassess
 your life choices.  `--force` should be a pretty clear warning sign.
 (If someone on the internet suggested `--force`, you can complain at
 _them_, but either way you should learn to carefully vet commands

--- a/Documentation/examples-from-user-filed-issues.md
+++ b/Documentation/examples-from-user-filed-issues.md
@@ -10,7 +10,7 @@ questions, which may be of interest to others.
 
   * [Adding files to root commits](#adding-files-to-root-commits)
   * [Purge a large list of files](#purge-a-large-list-of-files)
-  * [Extracting a libary from a repo](#Extracting-a-libary-from-a-repo)
+  * [Extracting a library from a repo](#Extracting-a-library-from-a-repo)
   * [Replace words in all commit messages](#Replace-words-in-all-commit-messages)
   * [Only keep files from two branches](#Only-keep-files-from-two-branches)
   * [Renormalize end-of-line characters and add a .gitattributes](#Renormalize-end-of-line-characters-and-add-a-gitattributes)
@@ -65,7 +65,7 @@ e.g. `../DELETED_FILENAMES.txt`, and then run
 git filter-repo --invert-paths --paths-from-file ../DELETED_FILENAMES.txt
 ```
 
-## Extracting a libary from a repo
+## Extracting a library from a repo
 
 <!-- https://github.com/newren/git-filter-repo/issues/80 -->
 
@@ -420,7 +420,7 @@ we are turning it into a new root commit.)
 <!-- https://github.com/newren/git-filter-repo/issues/492 -->
 
 Let's say you committed thousands of pngs that were poorly compressed,
-but later aggressively recompressed the pngs and commited and pushed.
+but later aggressively recompressed the pngs and committed and pushed.
 Unfortunately, clones are slow because they still contain the poorly
 compressed pngs and you'd like to rewrite history to pretend that the
 aggressively compressed versions were used when the files were first
@@ -454,7 +454,7 @@ git filter-repo --file-info-callback '
 <!-- https://github.com/newren/git-filter-repo/issues/537 -->
 
 Let's say you have a repo with a submodule at src/my-submodule, and
-that you feel the wrong commit-hashes of the submodule were commited
+that you feel the wrong commit-hashes of the submodule were committed
 within your project and you want them updated according to the
 following table:
 ```

--- a/git-filter-repo
+++ b/git-filter-repo
@@ -234,7 +234,7 @@ class AncestryGraph(object):
     # added to the AncestryGraph
     self.cur_value = 0
 
-    # A mapping from the external identifers given to us to the simple integers
+    # A mapping from the external identifiers given to us to the simple integers
     # we use in self.graph
     self.value = {}
 
@@ -1459,7 +1459,7 @@ class FastExportParser(object):
     # Create the progress message
     progress = Progress(message)
 
-    # Call any user callback to allow them to modify the progress messsage
+    # Call any user callback to allow them to modify the progress message
     if self._progress_callback:
       self._progress_callback(progress)
 
@@ -2306,7 +2306,7 @@ EXAMPLES
         # to avoid passing --reencode=yes to fast-export (that option was the
         # default prior to git-2.23)
         args.preserve_commit_encoding = None
-      # If we don't have fast-exoprt --reencode, we may also be missing
+      # If we don't have fast-export --reencode, we may also be missing
       # diff-tree --combined-all-paths, which is even more important...
       p = subproc.Popen('git diff-tree -h'.split(),
                         stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
@@ -3190,7 +3190,7 @@ class RepoFilter(object):
     self._commit_renames = {}
 
     # A set of original_ids (i.e. original hashes) for which we have not yet
-    # gotten the new hashses; the value is always the corresponding fast-export
+    # gotten the new hashes; the value is always the corresponding fast-export
     # id (i.e. commit.id)
     self._pending_renames = collections.OrderedDict()
 


### PR DESCRIPTION
To avoid having to deal with a potential number of PRs to fix typos in the future, let's try to get rid of a lot of them in advance right now.