### PR TITLE
Small fixes: a typo and a broken link

### DIFF
--- a/Documentation/git-filter-repo.txt
+++ b/Documentation/git-filter-repo.txt
@@ -290,7 +290,7 @@ Generic callback code snippets
 
 --file-info-callback <function_body>::
 	Python code body for processing the combination of filename, mode,
-	and associated file contents; see <<CALLBACKS>.  Note that when
+	and associated file contents; see <<CALLBACKS>>.  Note that when
 	--file-info-callback is specified, any replacements specified by
 	--replace-text will not be automatically applied; instead, you
 	have control within the --file-info-callback to choose which files

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ following apply:
 
 For comprehensive documentation:
   * see the [user manual](https://htmlpreview.github.io/?https://github.com/newren/git-filter-repo/blob/docs/html/git-filter-repo.html)
-  * alternative formating of the user manual is available on various
+  * alternative formatting of the user manual is available on various
     external sites
     ([example](https://www.mankier.com/1/git-filter-repo)), for those
     that don't like the htmlpreview.github.io layout, though it may


### PR DESCRIPTION
It looks like the authors of the following PRs:

- https://github.com/newren/git-filter-repo/pull/726
- https://github.com/newren/git-filter-repo/pull/733

will not amend their commit messages to append a Signed-off-by trailer.

The fixes are very small though, so let me just provide them here in properly signed off commits.